### PR TITLE
add copy methods for pulp_deb

### DIFF
--- a/extensions_admin/pulp_deb/extensions/admin/cudl.py
+++ b/extensions_admin/pulp_deb/extensions/admin/cudl.py
@@ -6,6 +6,7 @@ from pulp.client.commands.repo.cudl import CreateAndConfigureRepositoryCommand
 from pulp.client.commands.repo.cudl import ListRepositoriesCommand
 from pulp.client.commands.repo.cudl import UpdateRepositoryCommand
 from pulp.client.commands.repo.importer_config import ImporterConfigMixin
+from pulp.client.commands.unit import UnitCopyCommand
 from pulp.common.constants import REPO_NOTE_TYPE_KEY
 from pulp.client.extensions.extensions import PulpCliOption
 
@@ -195,3 +196,22 @@ class ListDebRepositoriesCommand(ListRepositoriesCommand):
             self.all_repos_cache = self.context.server.repo.repositories(query_params).response_body
 
         return self.all_repos_cache
+
+
+class CopyDebUnitCommand(UnitCopyCommand):
+    """
+    CLI Command for copying an iso unit from one repo to another
+    """
+    def __init__(self, context):
+        UnitCopyCommand.__init__(self, context, type_id=constants.DEB_TYPE_ID)
+
+    def get_formatter_for_type(self, type_id):
+        """
+        Hook to get a the formatter for a given type
+
+        :param type_id: the type id for which we need to get the formatter
+        :type type_id: str
+        :returns: a function to provide a user readable formatted name for a type
+        :rtype: function
+        """
+        return _get_formatter(type_id)

--- a/extensions_admin/pulp_deb/extensions/admin/cudl.py
+++ b/extensions_admin/pulp_deb/extensions/admin/cudl.py
@@ -214,4 +214,8 @@ class CopyDebUnitCommand(UnitCopyCommand):
         :returns: a function to provide a user readable formatted name for a type
         :rtype: function
         """
-        return _get_formatter(type_id)
+        return _get_details
+
+
+def _get_details(package):
+    return '%s-%s-%s' % (package['name'], package['version'], package['architecture'])

--- a/extensions_admin/pulp_deb/extensions/admin/cudl.py
+++ b/extensions_admin/pulp_deb/extensions/admin/cudl.py
@@ -200,7 +200,7 @@ class ListDebRepositoriesCommand(ListRepositoriesCommand):
 
 class CopyDebUnitCommand(UnitCopyCommand):
     """
-    CLI Command for copying an iso unit from one repo to another
+    CLI Command for copying an deb unit from one repo to another
     """
     def __init__(self, context):
         UnitCopyCommand.__init__(self, context, type_id=constants.DEB_TYPE_ID)
@@ -214,8 +214,8 @@ class CopyDebUnitCommand(UnitCopyCommand):
         :returns: a function to provide a user readable formatted name for a type
         :rtype: function
         """
-        return _get_details
+        if type_id is not constants.DEB_TYPE_ID:
+            raise ValueError(_("The deb module formatter can not process %s units.") % type_id)
 
-
-def _get_details(package):
-    return '%s-%s-%s' % (package['name'], package['version'], package['architecture'])
+        return lambda package: '%s-%s-%s' % (package['name'], package['version'],
+                                             package['architecture'])

--- a/extensions_admin/pulp_deb/extensions/admin/pulp_cli.py
+++ b/extensions_admin/pulp_deb/extensions/admin/pulp_cli.py
@@ -7,6 +7,7 @@ from pulp_deb.common import constants
 from pulp_deb.extensions.admin.cudl import CreateDebRepositoryCommand
 from pulp_deb.extensions.admin.cudl import UpdateDebRepositoryCommand
 from pulp_deb.extensions.admin.cudl import ListDebRepositoriesCommand
+from pulp_deb.extensions.admin.cudl import CopyDebUnitCommand
 
 SECTION_ROOT = 'deb'
 DESC_ROOT = _('manage deb repositories')
@@ -50,6 +51,7 @@ def add_repo_section(context, parent_section):
     repo_section.add_command(UpdateDebRepositoryCommand(context))
     repo_section.add_command(cudl.DeleteRepositoryCommand(context))
     repo_section.add_command(ListDebRepositoriesCommand(context))
+    repo_section.add_command(CopyDebUnitCommand(context))
 
     return repo_section
 

--- a/extensions_admin/test/unit/admin/test_cudl.py
+++ b/extensions_admin/test/unit/admin/test_cudl.py
@@ -1,6 +1,7 @@
 import unittest
+import types
 
-from mock import Mock
+from mock import Mock, MagicMock
 from pulp.common.constants import REPO_NOTE_TYPE_KEY
 from pulp.common.plugins.importer_constants import KEY_FEED
 from pulp.devel.unit.util import compare_dict
@@ -54,7 +55,6 @@ class TestCreateDebrRepositoryCommand(unittest.TestCase):
 
 
 class TestUpdateDebRepositoryCommand(unittest.TestCase):
-
     def setUp(self):
         self.context = Mock()
         self.context.config = {'output': {'poll_frequency_in_seconds': 3}}
@@ -180,3 +180,17 @@ class TestListDebRepositoriesCommand(unittest.TestCase):
         # Verify
         self.assertEqual(1, len(repos))
         self.assertEqual(repos[0]['repo_id'], 'non-deb-repo-1')
+
+
+class TestDebCopyCommand(unittest.TestCase):
+    def test_setup(self):
+        mock_context = MagicMock()
+        command = cudl.CopyDebUnitCommand(mock_context)
+        self.assertEquals(constants.DEB_TYPE_ID, command.type_id)
+
+    def test_get_formatter(self):
+        mock_context = MagicMock()
+        command = cudl.CopyDebUnitCommand(mock_context)
+        self.assertIsInstance(command.get_formatter_for_type(constants.DEB_TYPE_ID),
+                              types.FunctionType)
+        self.assertRaises(ValueError, command.get_formatter_for_type, 'fooType')

--- a/extensions_admin/test/unit/admin/test_pulp_cli.py
+++ b/extensions_admin/test/unit/admin/test_pulp_cli.py
@@ -8,6 +8,7 @@ from pulp.client.commands.repo.sync_publish import PublishStatusCommand,\
     RunPublishRepositoryCommand, RunSyncRepositoryCommand
 from pulp.client.extensions.core import PulpCli
 
+from pulp_deb.extensions.admin import cudl
 from pulp_deb.extensions.admin import pulp_cli
 
 
@@ -31,6 +32,7 @@ class TestInitialize(unittest.TestCase):
         self.assertTrue(isinstance(repo_section.commands['delete'], DeleteRepositoryCommand))
         self.assertTrue(isinstance(repo_section.commands['update'], UpdateRepositoryCommand))
         self.assertTrue(isinstance(repo_section.commands['list'], ListRepositoriesCommand))
+        self.assertTrue(isinstance(repo_section.commands['copy'], cudl.CopyDebUnitCommand))
 
         section = repo_section.subsections['sync']
         self.assertTrue(isinstance(section.commands['run'], RunSyncRepositoryCommand))

--- a/plugins/pulp_deb/plugins/importers/web.py
+++ b/plugins/pulp_deb/plugins/importers/web.py
@@ -98,6 +98,20 @@ class WebImporter(Importer):
         finally:
             shutil.rmtree(working_dir, ignore_errors=True)
 
+    def import_units(self, source_repo, dest_repo, import_conduit, config, units=None):
+        # Determine which units are being copied
+        if units is None:
+            repo = Repository.objects.get(repo_id=import_conduit.source_repo_id)
+            units = find_repo_content_units(repo, yield_content_unit=True)
+
+        # Associate to the new repository
+        units_to_return = []
+        for u in units:
+            units_to_return.append(u)
+            import_conduit.associate_unit(u)
+
+        return units_to_return
+
     def cancel_sync_repo(self):
         """
         Cancels an in-progress sync.

--- a/plugins/pulp_deb/plugins/importers/web.py
+++ b/plugins/pulp_deb/plugins/importers/web.py
@@ -6,6 +6,7 @@ from gettext import gettext as _
 
 from pulp.common.config import read_json_config
 from pulp.plugins.importer import Importer
+from pulp.server.db.model.criteria import UnitAssociationCriteria
 
 from pulp_deb.common import constants
 from pulp_deb.plugins.importers import sync
@@ -101,16 +102,14 @@ class WebImporter(Importer):
     def import_units(self, source_repo, dest_repo, import_conduit, config, units=None):
         # Determine which units are being copied
         if units is None:
-            repo = Repository.objects.get(repo_id=import_conduit.source_repo_id)
-            units = find_repo_content_units(repo, yield_content_unit=True)
+            criteria = UnitAssociationCriteria(type_ids=[constants.DEB_TYPE_ID])
+            units = import_conduit.get_source_units(criteria=criteria)
 
         # Associate to the new repository
-        units_to_return = []
         for u in units:
-            units_to_return.append(u)
             import_conduit.associate_unit(u)
 
-        return units_to_return
+        return units
 
     def cancel_sync_repo(self):
         """

--- a/run-tests.py
+++ b/run-tests.py
@@ -23,4 +23,5 @@ PLUGIN_TESTS = ['plugins/test/unit/']
 dir_safe_all_platforms = [os.path.join(os.path.dirname(__file__), x) for x in TESTS]
 dir_safe_non_rhel5 = [os.path.join(os.path.dirname(__file__), x) for x in PLUGIN_TESTS]
 
-sys.exit(run_tests(PACKAGES, dir_safe_all_platforms, dir_safe_non_rhel5))
+sys.exit(run_tests(PACKAGES, dir_safe_all_platforms, dir_safe_non_rhel5,
+                   flake8_paths=[PROJECT_DIR]))

--- a/run-tests.py
+++ b/run-tests.py
@@ -23,5 +23,4 @@ PLUGIN_TESTS = ['plugins/test/unit/']
 dir_safe_all_platforms = [os.path.join(os.path.dirname(__file__), x) for x in TESTS]
 dir_safe_non_rhel5 = [os.path.join(os.path.dirname(__file__), x) for x in PLUGIN_TESTS]
 
-sys.exit(run_tests(PACKAGES, dir_safe_all_platforms, dir_safe_non_rhel5,
-                   flake8_paths=[PROJECT_DIR]))
+sys.exit(run_tests(PACKAGES, dir_safe_all_platforms, dir_safe_non_rhel5))


### PR DESCRIPTION
Implemented importing for Debian Packages.
Adds support for copying Packages from one Debian Repository to another.