### PR TITLE
get_repo_relative_path: move lstrip into return statement

### DIFF
--- a/plugins/pulp_deb/plugins/distributors/configuration.py
+++ b/plugins/pulp_deb/plugins/distributors/configuration.py
@@ -181,8 +181,7 @@ def get_repo_relative_path(repo, config=None):
     cfg = config or {}
     relative_path = cfg.get(PUBLISH_RELATIVE_URL_KEYWORD, repo.id) or repo.id
 
-    relative_path.lstrip('/')
-    return relative_path
+    return relative_path.lstrip('/')
 
 
 def get_gpg_sign_options(repo=None, config=None):

--- a/plugins/test/unit/plugins/distributors/test_configuration.py
+++ b/plugins/test/unit/plugins/distributors/test_configuration.py
@@ -43,6 +43,11 @@ class TestConfigurationGetters(testbase.TestCase):
         directory = configuration.get_repo_relative_path(self.repo, self.config)
         self.assertEquals(directory, self.repo.id)
 
+    def test_get_repo_relative_path__with_slash(self):
+        cfg = self.config.__class__(dict(relative_url='/a/b'), dict())
+        directory = configuration.get_repo_relative_path(self.repo, cfg)
+        self.assertEquals(directory, 'a/b')
+
 
 class TestValidateConfig(testbase.TestCase):
     def _config_conduit(self):


### PR DESCRIPTION
method lstrip of string does not alter the immutable string
rendering the the instruction a noop