### PR TITLE
Remove intersphinx config and fix link to bugs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.intersphinx', 'sphinx.ext.extlinks']
+extensions = ['sphinx.ext.extlinks']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -239,17 +239,10 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
 
-# the "platform" URL needs to point to the correct version of platform docs for
-# this branch of the plugin. It is currently set to "latest" but may change as
-# code is branched and new RTD builders are created for platform.
-
-intersphinx_mapping = {'pylang': ('http://docs.python.org/2.7/', None),
-                       'platform': ("http://pulp.readthedocs.org/en/latest/", None)}
-
 extlinks = {'redmine': ('https://pulp.plan.io/issues/%s', '#'),
-            'fixedbugs': ('https://pulp.plan.io/projects/pulp_deb/issues?utf8=%%E2%%9C%%93&set_'
-                          'filter=1&f%%5B%%5D=cf_15&op%%5Bcf_15%%5D=%%3D&v%%5Bcf_15%%5D%%5B%%5D'
-                          '=%s&f%%5B%%5D=tracker_id&op%%5Btracker_id%%5D=%%3D&v%%5Btracker_id%%'
-                          '5D%%5B%%5D=1&f%%5B%%5D=&c%%5B%%5D=tracker&c%%5B%%5D=status&c%%5B%%5D'
-                          '=priority&c%%5B%%5D=cf_5&c%%5B%%5D=subject&c%%5B%%5D=author&c%%5B%%5'
-                          'D=assigned_to&c%%5B%%5D=cf_3&group_by=', 'bugs fixed in ')}
+            'fixedbugs_pulp_deb': ('https://pulp.plan.io/projects/pulp_deb/issues?utf8=%%E2%%9C%%93&set_'
+                                   'filter=1&f%%5B%%5D=cf_15&op%%5Bcf_15%%5D=%%3D&v%%5Bcf_15%%5D%%5B%%5D'
+                                   '=%s&f%%5B%%5D=tracker_id&op%%5Btracker_id%%5D=%%3D&v%%5Btracker_id%%'
+                                   '5D%%5B%%5D=1&f%%5B%%5D=&c%%5B%%5D=tracker&c%%5B%%5D=status&c%%5B%%5D'
+                                   '=priority&c%%5B%%5D=cf_5&c%%5B%%5D=subject&c%%5B%%5D=author&c%%5B%%5'
+                                   'D=assigned_to&c%%5B%%5D=cf_3&group_by=', 'bugs fixed in ')}


### PR DESCRIPTION
Intersphinx is no longer used in the docs building process.
Removing it from config will allow to build docs locally or for
the plugin itself without any issues.

A key for the bugs link in the extlinks dictionary should be unique
across all the plugins. It's important to specify it in platform docs
config. But in plugin it's useful to have it as well: to have an ability
to build docs for the plugin only without platform ones.