### PR TITLE
Fix http publishing

### DIFF
--- a/plugins/etc/httpd/conf.d/pulp_deb.conf
+++ b/plugins/etc/httpd/conf.d/pulp_deb.conf
@@ -1,11 +1,23 @@
-#
-# Apache configuration file for Pulp's Deb support
-#
+# -- split according to SSL-status
+<Location /pulp/deb/>
+  RewriteEngine On
+  RewriteCond %{HTTPS} on
+  RewriteRule (.+/pulp/deb/)(.*) /pulp/content/var/www/pub/deb/https/repos/$2 [DPI]
+  RewriteCond %{HTTPS} off
+  RewriteRule (.+/pulp/deb/)(.*) /pulp/content/var/www/pub/deb/http/repos/$2 [DPI]
+</Location>
 
-# -- HTTPS Repositories ---------
-
-Alias /pulp/deb /var/www/pub/deb/https/repos
-
+# -- HTTPS Repositories ----------
 <Directory /var/www/pub/deb/https>
+    WSGIAccessScript /usr/share/pulp/wsgi/repo_auth.wsgi
+    SSLRequireSSL
+    SSLVerifyClient optional
+    SSLVerifyDepth 9
+    SSLOptions +StdEnvVars +ExportCertData +FakeBasicAuth
+    Options FollowSymLinks Indexes
+</Directory>
+
+# -- HTTP Repositories ----------
+<Directory /var/www/pub/deb/http>
     Options FollowSymLinks Indexes
 </Directory>

--- a/plugins/pulp_deb/plugins/distributors/distributor.py
+++ b/plugins/pulp_deb/plugins/distributors/distributor.py
@@ -187,18 +187,16 @@ class Publisher(PluginStep):
             root_publish_dir = configuration.get_http_publish_dir(config)
             repo_publish_dir = os.path.join(root_publish_dir,
                                             repo_relative_path)
-            target_directories.append(root_publish_dir)
+            target_directories.append(('/', repo_publish_dir))
             listing_steps.append(GenerateListingFileStep(root_publish_dir,
                                                          repo_publish_dir))
         if config.get(constants.PUBLISH_HTTPS_KEYWORD):
             root_publish_dir = configuration.get_https_publish_dir(config)
             repo_publish_dir = os.path.join(root_publish_dir,
                                             repo_relative_path)
-            target_directories.append(root_publish_dir)
+            target_directories.append(('/', repo_publish_dir))
             listing_steps.append(GenerateListingFileStep(root_publish_dir,
                                                          repo_publish_dir))
-        target_directories = [('/', os.path.join(x, repo_relative_path))
-                              for x in target_directories]
         atomic_publish_step = AtomicDirectoryPublishStep(
             self.get_working_dir(),
             target_directories,


### PR DESCRIPTION
Due to a misconfiguration (config now stolen from pulp_rpm) the options serve-http(s) were not really useful.