### PR TITLE
gpg_cmd is not allowed as plugin or override configuration

### DIFF
--- a/plugins/test/unit/plugins/distributors/test_configuration.py
+++ b/plugins/test/unit/plugins/distributors/test_configuration.py
@@ -95,3 +95,15 @@ class TestValidateConfig(testbase.TestCase):
                            'conflicts with existing relative URL [/bar] ' +
                            'for repository [foo]'),
                           configuration.validate_config(repo, config, conduit))
+
+    def test__repocfg_gpg_cmd(self):
+        config = PluginCallConfiguration(
+            dict(http=True, https=False, relative_url='fool'),
+            dict(gpg_cmd="/bin/true should fail"))
+        repo = Mock(repo_id='fool', working_dir=self.work_dir)
+        conduit = self._config_conduit()
+
+        expected_reason = ('Configuration key [gpg_cmd] is not allowed '
+                           'in repository plugin configuration')
+        self.assertEquals((False, expected_reason),
+                          configuration.validate_config(repo, config, conduit))

--- a/plugins/test/unit/plugins/distributors/test_distributor.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor.py
@@ -8,6 +8,7 @@ import hashlib
 import mock
 from .... import testbase
 
+from pulp.plugins.config import PluginCallConfiguration
 from pulp_deb.common import ids, constants
 from pulp_deb.plugins.db import models
 
@@ -59,7 +60,7 @@ class TestConfiguration(BaseTest):
     def test_validate_config_empty(self):
         repo = mock.MagicMock(id="repo-1")
         conduit = self._config_conduit()
-        config = {}
+        config = PluginCallConfiguration({}, {})
         distributor = self.Module.DebDistributor()
         self.assertEquals(
             (False, '\n'.join([
@@ -76,8 +77,9 @@ class TestConfiguration(BaseTest):
 
         repo = mock.MagicMock(id="repo-1")
         conduit = self._config_conduit()
-        config = dict(http=True, https=False, relative_url=None,
-                      gpg_cmd=signer)
+        config = PluginCallConfiguration(
+            dict(gpg_cmd=signer),
+            dict(http=True, https=False, relative_url=None))
         distributor = self.Module.DebDistributor()
         self.assertEquals(
             distributor.validate_config(repo, config, conduit),
@@ -89,8 +91,9 @@ class TestConfiguration(BaseTest):
 
         repo = mock.MagicMock(id="repo-1")
         conduit = self._config_conduit()
-        config = dict(http=True, https=False, relative_url=None,
-                      gpg_cmd=signer)
+        config = PluginCallConfiguration(
+            dict(gpg_cmd=signer),
+            dict(http=True, https=False, relative_url=None))
         distributor = self.Module.DebDistributor()
         self.assertEquals(
             (False, '\n'.join([


### PR DESCRIPTION
Since the command configured with gpg_cmd executes remotely as user apache,
a user should not be allowed to change it via a distributor config or
an override at publish time.

Fixes #3498
https://pulp.plan.io/issues/3498

Change-Id: I88cdb4f51c237b1157e7424863df7049269939ca