### PR TITLE
Verify fingerprints compatibility

### DIFF
--- a/plugins/pulp_deb/plugins/importers/sync.py
+++ b/plugins/pulp_deb/plugins/importers/sync.py
@@ -156,13 +156,14 @@ class ParseReleaseStep(publish_step.PluginStep):
         gpg = gnupg.GPG(homedir=os.path.join(self.get_working_dir(), 'gpg-home'))
         shared_gpg = gnupg.GPG(homedir=os.path.join('/', 'var', 'lib', 'pulp', 'gpg-home'))
 
+        keyserver = self.get_config().get(constants.CONFIG_KEYSERVER,
+                                          constants.CONFIG_KEYSERVER_DEFAULT)
+
         fingerprints = self.get_config().get(constants.CONFIG_ALLOWED_KEYS).split(',')
         # TODO check if full fingerprints are provided
         for fingerprint in fingerprints:
             if fingerprint not in [
                     key['fingerprint'] for key in shared_gpg.list_keys()]:
-                keyserver = self.get_config().get(constants.CONFIG_KEYSERVER,
-                                                  constants.CONFIG_KEYSERVER_DEFAULT)
                 shared_gpg.recv_keys(keyserver, fingerprint)
         gpg.import_keys(shared_gpg.export_keys(fingerprints))
         if not os.path.isfile(self.parent.release_files[release] + '.gpg'):

--- a/plugins/pulp_deb/plugins/importers/sync.py
+++ b/plugins/pulp_deb/plugins/importers/sync.py
@@ -169,9 +169,11 @@ class ParseReleaseStep(publish_step.PluginStep):
         keyserver = self.get_config().get(constants.CONFIG_KEYSERVER,
                                           constants.CONFIG_KEYSERVER_DEFAULT)
 
-        fingerprints = self.get_config().get(constants.CONFIG_ALLOWED_KEYS).split(',')
+        fingerprints = split_or_none(self.get_config().get(constants.CONFIG_ALLOWED_KEYS)) or []
         # TODO check if full fingerprints are provided
         for fingerprint in fingerprints:
+            # remove spaces from fingerprint (space would mark the next key)
+            fingerprint = fingerprint.replace(' ', '')
             if fingerprint not in [
                     key['fingerprint'] for key in shared_gpg.list_keys()]:
                 shared_gpg.recv_keys(keyserver, fingerprint)
@@ -385,5 +387,5 @@ def generate_internal_storage_path(filename):
 
 def split_or_none(data):
     if data:
-        return data.split(',')
+        return [x.strip() for x in data.split(',')]
     return None


### PR DESCRIPTION
Add backwards-compatibility for:
* older pulp-versions (`get_boolean()` without default-value)
* older gnupg-versions (`homedir` vs. `gnupghome`, order of parameters in `verify()`)

Moved determining keyserver out of loop.