### PR TITLE
Account for components with an extra path prefix

### DIFF
--- a/plugins/pulp_deb/plugins/importers/sync.py
+++ b/plugins/pulp_deb/plugins/importers/sync.py
@@ -226,7 +226,7 @@ class ParseReleaseStep(publish_step.PluginStep):
                 pass
             # get release component units
             for component in repometa.components:
-                if components is None or component in components:
+                if components is None or component.split('/')[-1] in components:
                     comp_unit = self.parent.component_units[release][component] = \
                         models.DebComponent.get_or_create_and_associate(self.parent.repo,
                                                                         rel_unit,
@@ -244,7 +244,7 @@ class ParseReleaseStep(publish_step.PluginStep):
             if components:
                 rel_dl_reqs = [
                     dlr for dlr in rel_dl_reqs
-                    if dlr.data['component'] in components]
+                    if dlr.data['component'].split('/')[-1] in components]
             if architectures:
                 rel_dl_reqs = [
                     dlr for dlr in rel_dl_reqs


### PR DESCRIPTION
The components in the repo metadata object ('Release' file) may be
prefixed. This prefix must be stripped from certain comparisons.
See also: https://wiki.debian.org/DebianRepository/Format#Components

~~Also sets the 'suite' correctly~~. (EDIT: This has already been fixed in master).

Fixes #4008
https://pulp.plan.io/issues/4008

~~WARNING: These changes are dependent on changes in python-debpkgr to work (as well as to fully resolve the issue).
Do not merge/release before the following pull request has made it into python-debpkgr:
https://github.com/sassoftware/python-debpkgr/pull/13~~

EDIT: With the merge of https://github.com/pulp/pulp_deb/pull/57 into master, the dependency to python-debpkgr https://github.com/sassoftware/python-debpkgr/pull/13 no longer exists!
