### PR TITLE
Add missing gnupg dependency + correct indenting in setup.py

### DIFF
--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -31,5 +31,6 @@ setup(
         ('/usr/lib/pulp/plugins/types', ['types/deb.json']),
     ],
     install_requires=[
+        'gnupg',
     ],
 )

--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -24,8 +24,8 @@ setup(
             'deb_release=pulp_deb.plugins.db.models:DebRelease',
             'deb_component=pulp_deb.plugins.db.models:DebComponent',
         ],
-   },
-   include_package_data=True,
+    },
+    include_package_data=True,
     data_files=[
         ('/etc/httpd/conf.d', ['etc/httpd/conf.d/pulp_deb.conf']),
         ('/usr/lib/pulp/plugins/types', ['types/deb.json']),


### PR DESCRIPTION
bc9c24693cb9c6db8cbcd565d11ed6ecb6ad178f added gnupg as a dependency but it wasn't declared as such.