### PR TITLE
fix the gnupg package name in setup

### DIFF
--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -31,6 +31,6 @@ setup(
         ('/usr/lib/pulp/plugins/types', ['types/deb.json']),
     ],
     install_requires=[
-        'gnupg',
+        'python-gnupg',
     ],
 )


### PR DESCRIPTION
while you `import gnupg`, the package is called `python-gnupg` on PyPI

otherwise Pulp fails to load it:

    Loading unit model: deb_release = pulp_deb.plugins.db.models:DebRelease
    gnupg
    Traceback (most recent call last):
      File "/usr/lib/python2.7/site-packages/pulp/server/db/manage.py", line 236, in main
        return _auto_manage_db(options)
      File "/usr/lib/python2.7/site-packages/pulp/server/db/manage.py", line 267, in _auto_manage_db
        old_content_types = load_content_types(dry_run=options.dry_run)
      File "/usr/lib/python2.7/site-packages/pulp/plugins/loader/api.py", line 438, in load_content_types
        mongoengine_definitions = _generate_plugin_definitions()
      File "/usr/lib/python2.7/site-packages/pulp/plugins/loader/api.py", line 519, in _generate_plugin_definitions
        plugin_manager = PluginManager()
      File "/usr/lib/python2.7/site-packages/pulp/plugins/loader/manager.py", line 36, in __init__
        self._load_unit_models()
      File "/usr/lib/python2.7/site-packages/pulp/plugins/loader/manager.py", line 54, in _load_unit_models
        model_class = entry_point.load()
      File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 2259, in load
        if require: self.require(env, installer)
      File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 2272, in require
        working_set.resolve(self.dist.requires(self.extras),env,installer)))
      File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 626, in resolve
        raise DistributionNotFound(req)
    DistributionNotFound: gnupg