### PR TITLE
MetadataStep performance

### DIFF
--- a/plugins/pulp_deb/plugins/db/models.py
+++ b/plugins/pulp_deb/plugins/db/models.py
@@ -226,6 +226,25 @@ class DebPackage(FileContentUnit):
         cstype = util.TYPE_SHA256
         return util.calculate_checksums(fobj, [cstype])[cstype]
 
+    @staticmethod
+    def calculate_deb_checksums(input_file_path):
+        """
+        Uses util.calculate_checksums() to calculate the md5sum, sha1, and sha256
+        of a file. The return dict is guaranteed to use the deb style keys
+        'md5sum', 'sha1', and 'sha256'.
+
+        :param file_path: the path to the file for which checksums are needed
+        :returns: a dict containing the checksums
+        """
+        CHECKSUM_TYPES = {
+            'md5sum': util.TYPE_MD5,
+            'sha1': util.TYPE_SHA1,
+            'sha256': util.TYPE_SHA256,
+        }
+        with open(input_file_path) as input_file:
+            checksums = util.calculate_checksums(input_file, CHECKSUM_TYPES.values())
+        return {deb_key: checksums[util_key] for deb_key, util_key in CHECKSUM_TYPES.items()}
+
     @classmethod
     def filename_from_unit_key(cls, unit_key):
         return "{0}_{1}_{2}.{3}".format(

--- a/plugins/pulp_deb/plugins/distributors/configuration.py
+++ b/plugins/pulp_deb/plugins/distributors/configuration.py
@@ -107,7 +107,7 @@ def validate_config(repo, config, config_conduit):
                                        error_messages)
 
     try:
-        get_gpg_sign_options(repo, config)
+        get_gpg_signer(repo, config)
     except signer.SignerError as e:
         error_messages.append(str(e))
 
@@ -201,18 +201,20 @@ def get_repo_relative_path(repo, config=None):
     return relative_path.lstrip('/')
 
 
-def get_gpg_sign_options(repo=None, config=None):
+def get_gpg_signer(repo=None, config=None):
     cfg = config or {}
     cmd = cfg.get(GPG_CMD)
     if not cmd:
         return None
     key_id = cfg.get(GPG_KEY_ID)
     repository_name = None if repo is None else repo.id
-    return signer.SignOptions(cmd, repository_name=repository_name,
-                              key_id=key_id)
+    sign_options = signer.SignOptions(cmd, repository_name=repository_name,
+                                      key_id=key_id)
+    return signer.Signer(sign_options)
 
 
 # -- required config validation -----------------------------------------------
+
 
 def _validate_http(http, error_messages):
     _validate_boolean(HTTP_PUBLISH_DIR_KEYWORD, http, error_messages)
@@ -238,6 +240,7 @@ def _validate_relative_url(relative_url, error_messages):
 
 
 # -- optional config validation -----------------------------------------------
+
 
 def _validate_http_publish_dir(http_publish_dir, error_messages):
     _validate_usable_directory(HTTP_PUBLISH_DIR_KEYWORD, http_publish_dir,

--- a/plugins/pulp_deb/plugins/distributors/distributor.py
+++ b/plugins/pulp_deb/plugins/distributors/distributor.py
@@ -290,14 +290,6 @@ class MetadataStep(PluginStep):
         config = self.get_config()
         base_path = self.get_working_dir()
 
-        # Add missing checksum fields (this is bad for performance):
-        # This is a temporary fix!
-        for package in unit_dict.itervalues():
-            checksums = models.DebPackage.calculate_deb_checksums(package.storage_path)
-            package.sha1 = checksums['sha1']
-            package.sha256 = checksums['sha256']
-            package.md5sum = checksums['md5sum']
-
         # Do nothing, if the repository is empty (review this behaviour):
         if len(unit_dict) == 0:
             return

--- a/plugins/pulp_deb/plugins/distributors/metadata_files.py
+++ b/plugins/pulp_deb/plugins/distributors/metadata_files.py
@@ -79,14 +79,9 @@ def write_packages_file_paragraph(packages_file, component, package):
         ('sha256', 'SHA256'),
     ]
 
-    # Write all non-checksum fields:
     package_properties = package.all_properties
-    # Manually add monkeypatched fields:
-    # This is a temporary fix!
-    package_properties['md5sum'] = package.md5sum
-    package_properties['sha1'] = package.sha1
-    package_properties['sha256'] = package.sha256
     packages_object = deb822.Packages()
+
     for field in fields:
         if field[0] == 'filename':
             # TODO: A better pool folder structure is desirable.

--- a/plugins/pulp_deb/plugins/distributors/metadata_files.py
+++ b/plugins/pulp_deb/plugins/distributors/metadata_files.py
@@ -1,0 +1,218 @@
+"""
+This file provides functions for writing 'Release' and 'Packages' files.
+It also provides functions for compressing and signing these files.
+"""
+
+import os
+import gzip
+import shutil
+import bz2
+import time
+
+from debian import deb822
+from pulp_deb.plugins.db.models import DebPackage
+
+BUFFER_SIZE = 65536
+
+
+def write_packages_file(path, component, packages):
+    """
+    Writes a 'Packages' file for an apt repository.
+    This function assumes the file ":path:/Packages" does not exist.
+
+    :param path: the path to the folder where the 'Packages' file will be placed
+    :param component: the release component to which the packages file belongs
+                      (this is needed for the 'pool' path of each package)
+    :returns: the path to the 'Packages' file
+    """
+    output_file_path = os.path.join(path, 'Packages')
+
+    with open(output_file_path, 'a') as packages_file:
+        for package in packages:
+            write_packages_file_paragraph(packages_file, component, package)
+            packages_file.write('\n')
+
+    return output_file_path
+
+
+def write_packages_file_paragraph(packages_file, component, package):
+    """
+    Writes a single 'Packages' file paragraph (the entry for a single package).
+    This function assumes the object supplied by :package: is correct.
+    The order of entries are extracted from an official Debian mirror.
+
+    :param packages_file: the file handle that is written to
+    :param component: the release component to which the packages file belongs
+                      (this is needed for the 'pool' path of each package)
+    :param package: a single DebPackage object
+    """
+    # Ordered list of supported fields (tuples):
+    # Known to exist but currently unsupported fields include:
+    # "Description-md5" (after 'homepage')
+    # "Tag" (after "Description-md5")
+    fields = [
+        ('name', 'Package'),
+        ('source', 'Source'),
+        ('version', 'Version'),
+        ('installed_size', 'Installed-Size'),
+        ('maintainer', 'Maintainer'),
+        ('original_maintainer', 'Original-Maintainer'),
+        ('architecture', 'Architecture'),
+        ('replaces', 'Replaces'),
+        ('provides', 'Provides'),
+        ('depends', 'Depends'),
+        ('pre_depends', 'Pre-Depends'),
+        ('recommends', 'Recommends'),
+        ('suggests', 'Suggests'),
+        ('enhances', 'Enhances'),
+        ('conflicts', 'Conflicts'),
+        ('breaks', 'Breaks'),
+        ('description', 'Description'),
+        ('multi_arch', 'Multi-Arch'),
+        ('homepage', 'Homepage'),
+        ('section', 'Section'),
+        ('priority', 'Priority'),
+        ('filename', 'Filename'),
+        ('size', 'Size'),
+        ('md5sum', 'MD5sum'),
+        ('sha1', 'SHA1'),
+        ('sha256', 'SHA256'),
+    ]
+
+    # Write all non-checksum fields:
+    package_properties = package.all_properties
+    # Manually add monkeypatched fields:
+    # This is a temporary fix!
+    package_properties['md5sum'] = package.md5sum
+    package_properties['sha1'] = package.sha1
+    package_properties['sha256'] = package.sha256
+    packages_object = deb822.Packages()
+    for field in fields:
+        if field[0] == 'filename':
+            # TODO: A better pool folder structure is desirable.
+            relative_pool_path = os.path.join('pool',
+                                              component,
+                                              package.filename,)
+            packages_object['Filename'] = relative_pool_path
+        elif package_properties[field[0]]:
+            packages_object[field[1]] = cast_to_utf8_unicode(package_properties[field[0]])
+
+    packages_object.dump(packages_file)
+
+
+def write_release_file(path, meta_data, release_meta_files):
+    """
+    Writes a 'Release' file for an apt repository.
+    This function assumes the file ":path:/Release" does not exist.
+
+    :param path: the path to the folder where the 'Release' file will be placed
+    :param meta_data: a dict containing the needed meta data
+    :param release_meta_files: a list of paths to files to be included
+    :returns: the path to the 'Release' file
+    """
+    output_file_path = os.path.join(path, 'Release')
+
+    # Ordered list of supported non-checksum fields (tuples):
+    # Known to exist but currently unsupported fields include:
+    # "Acquire-By-Hash" (after 'date')
+    fields = [
+        ('origin', 'Origin'),
+        ('label', 'Label'),
+        ('suite', 'Suite'),
+        ('version', 'Version'),
+        ('codename', 'Codename'),
+        ('changelogs', 'Changelogs'),
+        ('date', 'Date'),
+        ('architectures', 'Architectures'),
+        ('components', 'Components'),
+        ('description', 'Description'),
+    ]
+    # Ordered list of supported checksum fields (tuples):
+    checksum_fields = [
+        ('md5sum', 'MD5sum'),
+        ('sha1', 'SHA1'),
+        ('sha256', 'SHA256'),
+    ]
+
+    # Amend or add incomplete fields:
+    meta_data['architectures'] = " ".join(meta_data['architectures'])
+    meta_data['components'] = " ".join(meta_data['components'])
+    meta_data['date'] = time.strftime('%a, %d %b %Y %H:%M:%S +0000', time.gmtime())
+
+    # Initialize deb822 object:
+    release = deb822.Release()
+
+    # Translate meta_data to deb822 for all fields (without checksum_fields):
+    for field in fields:
+        if field[0] in meta_data:
+            release[field[1]] = meta_data[field[0]]
+
+    # Initialize the needed deb822 checksum fields:
+    release['MD5sum'] = []
+    release['SHA1'] = []
+    release['SHA256'] = []
+
+    # Add the checksum fields to the deb822 object:
+    for file_path in release_meta_files:
+        checksums = DebPackage.calculate_deb_checksums(file_path)
+        file_size = os.path.getsize(file_path)
+        relative_path = os.path.relpath(file_path, path)
+        for checksum_type in checksum_fields:
+            release[checksum_type[1]].append({checksum_type[0]: checksums[checksum_type[0]],
+                                              'size': file_size,
+                                              'name': relative_path})
+
+    # Write the deb822 object to a file:
+    with open(output_file_path, "wb") as release_file:
+        release.dump(release_file)
+
+    return output_file_path
+
+
+def gzip_compress_file(input_file_path):
+    """
+    Compresses a file using gzip. The compressed file is appended with '.gz'.
+
+    :param input_file_path: the path to the file that is to be compressed
+    :returns: the path to the compressed file
+    """
+    output_file_path = '{}.gz'.format(input_file_path)
+
+    with open(input_file_path, 'rb') as input_file:
+        with gzip.open(output_file_path, 'wb') as output_file:
+            shutil.copyfileobj(input_file, output_file)
+
+    return output_file_path
+
+
+def bz2_compress_file(input_file_path):
+    """
+    Compresses a file using bz2. The compressed file is appended with '.bz2'.
+
+    :param input_file_path: the path to the file that is to be compressed
+    :returns: the path to the compressed file
+    """
+    output_file_path = '{}.bz2'.format(input_file_path)
+
+    with open(input_file_path, 'rb') as input_file:
+        with open(output_file_path, 'wb') as output_file:
+            output_file.write(bz2.compress(input_file.read()))
+
+    return output_file_path
+
+
+def cast_to_utf8_unicode(obj):
+    """
+    Will cast input of type 'int' or 'str' to 'unicode' using utf8 and return
+    other types unchanged.
+
+    :param obj: the object to be casted
+    :returns: an unicode string using utf8 encoding or obj
+    """
+    if type(obj) == str:
+        return_value = obj.decode('utf8')
+    elif type(obj) == int:
+        return_value = str(obj).decode('utf8')
+    else:
+        return_value = obj
+    return return_value

--- a/plugins/pulp_deb/plugins/migrations/0003_add_multiple_hashes.py
+++ b/plugins/pulp_deb/plugins/migrations/0003_add_multiple_hashes.py
@@ -1,0 +1,56 @@
+import logging
+import os
+
+from pulp.server import util as server_utils
+from pulp.server.db import connection
+from pulp.server.db.migrations.lib import utils as migration_utils
+
+
+_logger = logging.getLogger(__name__)
+
+CHECKSUM_TYPES = [server_utils.TYPE_MD5,
+                  server_utils.TYPE_SHA1,
+                  server_utils.TYPE_SHA256]
+
+
+def migrate(*args, **kwargs):
+    """
+    Add seperate fields for md5sum, sha1, sha256
+    """
+    warnings_encountered = False
+    deb_collection = connection.get_collection('units_deb')
+    deb_count = deb_collection.count()
+
+    with migration_utils.MigrationProgressLog('Deb Package', deb_count) as progress_log:
+        for deb_package in deb_collection.find({}).batch_size(100):
+            storage_path = deb_package['_storage_path']
+            package_id = deb_package['_id']
+            if not os.path.exists(storage_path):
+                warnings_encountered = True
+                msg = 'deb package file corresponding to db_unit with _id = {}\n'\
+                      'was not found at _storage_path = {}.\n'\
+                      'The unit was not migrated!'.format(package_id, storage_path)
+                _logger.warn(msg)
+                continue
+
+            with open(storage_path, 'r') as file_handle:
+                checksums = server_utils.calculate_checksums(file_handle, CHECKSUM_TYPES)
+
+            new_fields = {
+                'md5sum': checksums[server_utils.TYPE_MD5],
+                'sha1': checksums[server_utils.TYPE_SHA1],
+                'sha256': checksums[server_utils.TYPE_SHA256],
+            }
+
+            if checksums[deb_package['checksumtype']] != deb_package['checksum']:
+                raise Exception('New checksum does not match existing checksum for\n'
+                                '_id = {}\nfile = {}'.format(package_id, storage_path))
+
+            deb_collection.update_one({'_id': package_id},
+                                      {'$set': new_fields},)
+            progress_log.progress()
+
+    if warnings_encountered:
+        msg = 'Warnings were encountered during the db migration!\n'\
+              'Check the logs for more information, and consider deleting broken units.'
+        _logger.warn(msg)

--- a/plugins/test/testbase.py
+++ b/plugins/test/testbase.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 from pulp.server import config
 config.check_config_files = lambda *args: None
 
-File = namedtuple("File", "path checksum")
+File = namedtuple("File", "path checksum md5sum sha1 sha256")
 
 
 class TestCase(unittest.TestCase):
@@ -36,7 +36,9 @@ class TestCase(unittest.TestCase):
             contents = str(uuid.uuid4())
         elif isinstance(contents, (dict, list)):
             contents = json.dumps(contents)
-        checksum = hashlib.sha256(contents).hexdigest()
+        sha256 = hashlib.sha256(contents).hexdigest()
+        sha1 = hashlib.sha1(contents).hexdigest()
+        md5sum = hashlib.md5(contents).hexdigest()
         with open(file_path, "w") as fobj:
             fobj.write(contents)
-        return File(file_path, checksum)
+        return File(file_path, sha256, md5sum, sha1, sha256)

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -30,17 +30,26 @@ class TestModel(testbase.TestCase):
 
     def test_from_file_different_checksumtype(self):
         metadata = dict(checksumtype='sha1',
-                        checksum='fake')
+                        checksum='fake',)
         pkg_path = os.path.join(DATA_DIR, "nscd_2.24-7ubuntu2_amd64.deb")
         pkg = models.DebPackage.from_file(pkg_path, metadata)
         self.assertTrue(isinstance(pkg, models.DebPackage))
         self.assertEquals(pkg.unit_key['name'], 'nscd')
         self.assertEquals(
-            'sha256',
-            pkg.checksumtype)
+            pkg.md5sum,
+            '0574983471a3a2cea6fb5c30ce6864ed',)
         self.assertEquals(
-            '177937795c2ef5b381718aefe2981ada4e8cfe458226348d87a6f5b100a4612b',
-            pkg.checksum)
+            pkg.sha1,
+            '4ca6fcfa6f063cfe38cd1334255b177238441340',)
+        self.assertEquals(
+            pkg.sha256,
+            '177937795c2ef5b381718aefe2981ada4e8cfe458226348d87a6f5b100a4612b',)
+        self.assertEquals(
+            pkg.checksumtype,
+            'sha256',)
+        self.assertEquals(
+            pkg.checksum,
+            '177937795c2ef5b381718aefe2981ada4e8cfe458226348d87a6f5b100a4612b',)
 
     def test_from_file_no_file(self):
         with self.assertRaises(ValueError) as cm:

--- a/plugins/test/unit/plugins/distributors/test_distributor.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor.py
@@ -120,9 +120,11 @@ class PublishRepoMixIn(object):
                 _p = unit._storage_path = os.path.join(
                     storage_dir, unit.filename)
                 open(_p, "wb").write(str(uuid.uuid4()))
+                unit.md5sum = hashlib.md5(open(_p, "rb").read()).hexdigest()
+                unit.sha1 = hashlib.sha1(open(_p, "rb").read()).hexdigest()
+                unit.sha256 = hashlib.sha256(open(_p, "rb").read()).hexdigest()
                 unit.checksumtype = 'sha256'
-                unit.checksum = hashlib.sha256(
-                    open(_p, "rb").read()).hexdigest()
+                unit.checksum = unit.sha256
             except Exception:
                 pass
         return units
@@ -285,10 +287,20 @@ class PublishRepoMixIn(object):
 class TestPublishOldRepoDeb(PublishRepoMixIn, BaseTest):
     Sample_Units = {
         models.DebPackage: [
-            dict(name='burgundy', version='0.1938.0', architecture='amd64',
-                 checksum='abcde', checksumtype='sha3.14', id='bbbb'),
-            dict(name='chablis', version='0.2013.0', architecture='amd64',
-                 checksum='yz', checksumtype='sha3.14', id='cccc'),
+            dict(
+                name='burgundy',
+                version='0.1938.0',
+                architecture='amd64',
+                control_fields=dict(Package='burgundy'),
+                id='bbbb',
+            ),
+            dict(
+                name='chablis',
+                version='0.2013.0',
+                architecture='amd64',
+                control_fields=dict(Package='chablis'),
+                id='cccc',
+            ),
         ],
         models.DebComponent: [
         ],
@@ -302,13 +314,28 @@ class TestPublishOldRepoDeb(PublishRepoMixIn, BaseTest):
 class TestPublishRepoDeb(PublishRepoMixIn, BaseTest):
     Sample_Units = {
         models.DebPackage: [
-            dict(name='burgundy', version='0.1938.0', architecture='amd64',
-                 checksum='abcde', checksumtype='sha3.14', id='bbbb'),
-            dict(name='chablis', version='0.2013.0', architecture='amd64',
-                 checksum='yz', checksumtype='sha3.14', id='cccc'),
+            dict(
+                name='burgundy',
+                version='0.1938.0',
+                architecture='amd64',
+                control_fields=dict(Package='burgundy'),
+                id='bbbb',
+            ),
+            dict(
+                name='chablis',
+                version='0.2013.0',
+                architecture='amd64',
+                control_fields=dict(Package='chablis'),
+                id='cccc',
+            ),
         ],
         models.DebComponent: [
-            dict(name='main', release='stable', id='mainid', packages=['bbbb', 'cccc']),
+            dict(
+                name='main',
+                release='stable',
+                id='mainid',
+                packages=['bbbb', 'cccc']
+            ),
         ],
         models.DebRelease: [
             dict(codename='stable', id='stableid'),
@@ -321,18 +348,42 @@ class TestPublishRepoDeb(PublishRepoMixIn, BaseTest):
 class TestPublishRepoMultiArchDeb(PublishRepoMixIn, BaseTest):
     Sample_Units = {
         models.DebPackage: [
-            dict(name='burgundy', version='0.1938.0', architecture='amd64',
-                 checksum='abcde', checksumtype='sha3.14', id='bbbb'),
-            dict(name='chablis', version='0.2013.0', architecture='amd64',
-                 checksum='yz', checksumtype='sha3.14', id='cccc'),
-            dict(name='dornfelder', version='0.2017.0', architecture='i386',
-                 checksum='wxy', checksumtype='sha3.14', id='dddd'),
-            dict(name='elbling', version='0.2017.0', architecture='all',
-                 checksum='foo', checksumtype='sha3.14', id='eeee'),
+            dict(
+                name='burgundy',
+                version='0.1938.0',
+                architecture='amd64',
+                control_fields=dict(Package='burgundy'),
+                id='bbbb',
+            ),
+            dict(
+                name='chablis',
+                version='0.2013.0',
+                architecture='amd64',
+                control_fields=dict(Package='chablis'),
+                id='cccc',
+            ),
+            dict(
+                name='dornfelder',
+                version='0.2017.0',
+                architecture='i386',
+                control_fields=dict(Package='dornfelder'),
+                id='dddd',
+            ),
+            dict(
+                name='elbling',
+                version='0.2017.0',
+                architecture='all',
+                control_fields=dict(Package='elbling'),
+                id='eeee',
+            ),
         ],
         models.DebComponent: [
-            dict(name='main', release='stable', id='mainid',
-                 packages=['bbbb', 'cccc', 'dddd', 'eeee']),
+            dict(
+                name='main',
+                release='stable',
+                id='mainid',
+                packages=['bbbb', 'cccc', 'dddd', 'eeee'],
+            ),
         ],
         models.DebRelease: [
             dict(codename='stable', id='stableid'),
@@ -345,22 +396,55 @@ class TestPublishRepoMultiArchDeb(PublishRepoMixIn, BaseTest):
 class TestPublishRepoMultiCompArchDeb(PublishRepoMixIn, BaseTest):
     Sample_Units = {
         models.DebPackage: [
-            dict(name='burgundy', version='0.1938.0', architecture='amd64',
-                 checksum='abcde', checksumtype='sha3.14', id='bbbb'),
-            dict(name='chablis', version='0.2013.0', architecture='amd64',
-                 checksum='yz', checksumtype='sha3.14', id='cccc'),
-            dict(name='dornfelder', version='0.2017.0', architecture='i386',
-                 checksum='wxy', checksumtype='sha3.14', id='dddd'),
-            dict(name='elbling', version='0.2017.0', architecture='all',
-                 checksum='foo', checksumtype='sha3.14', id='eeee'),
-            dict(name='federweisser', version='0.2017.0', architecture='ppc',
-                 checksum='foo', checksumtype='sha3.14', id='ffff'),
+            dict(
+                name='burgundy',
+                version='0.1938.0',
+                architecture='amd64',
+                control_fields=dict(Package='burgundy'),
+                id='bbbb',
+            ),
+            dict(
+                name='chablis',
+                version='0.2013.0',
+                architecture='amd64',
+                control_fields=dict(Package='chablis'),
+                id='cccc',
+            ),
+            dict(
+                name='dornfelder',
+                version='0.2017.0',
+                architecture='i386',
+                control_fields=dict(Package='dornfelder'),
+                id='dddd',
+            ),
+            dict(
+                name='elbling',
+                version='0.2017.0',
+                architecture='all',
+                control_fields=dict(Package='elbling'),
+                id='eeee',
+            ),
+            dict(
+                name='federweisser',
+                version='0.2017.0',
+                architecture='ppc',
+                control_fields=dict(Package='federweisser'),
+                id='ffff',
+            ),
         ],
         models.DebComponent: [
-            dict(name='main', release='old-stable', id='mainid',
-                 packages=['bbbb', 'cccc', 'dddd', 'eeee', 'ffff']),
-            dict(name='premature', release='old-stable', id='preid',
-                 packages=['cccc', 'dddd', 'eeee', 'ffff']),
+            dict(
+                name='main',
+                release='old-stable',
+                id='mainid',
+                packages=['bbbb', 'cccc', 'dddd', 'eeee', 'ffff'],
+            ),
+            dict(
+                name='premature',
+                release='old-stable',
+                id='preid',
+                packages=['cccc', 'dddd', 'eeee', 'ffff'],
+            ),
         ],
         models.DebRelease: [
             dict(codename='old-stable', id='oldstableid'),
@@ -379,20 +463,45 @@ class TestPublishAllArchCompDeb(PublishRepoMixIn, BaseTest):
     """
     Sample_Units = {
         models.DebPackage: [
-            dict(name='burgundy', version='0.1938.0', architecture='all',
-                 checksum='abcde', checksumtype='sha3.14', id='bbbb'),
-            dict(name='chablis', version='0.2013.0', architecture='all',
-                 checksum='yz', checksumtype='sha3.14', id='cccc'),
-            dict(name='dornfelder', version='0.2017.0', architecture='all',
-                 checksum='wxy', checksumtype='sha3.14', id='dddd'),
-            dict(name='federweisser', version='0.2017.0', architecture='amd64',
-                 checksum='foo', checksumtype='sha3.14', id='ffff'),
+            dict(
+                name='burgundy',
+                version='0.1938.0',
+                architecture='all',
+                control_fields=dict(Package='burgundy'),
+                id='bbbb',
+            ),
+            dict(
+                name='chablis',
+                version='0.2013.0',
+                architecture='all',
+                control_fields=dict(Package='chablis'),
+                id='cccc',
+            ),
+            dict(
+                name='dornfelder',
+                version='0.2017.0',
+                architecture='all',
+                control_fields=dict(Package='dornfelder'),
+                id='dddd',
+            ),
+            dict(
+                name='federweisser',
+                version='0.2017.0',
+                architecture='amd64',
+                control_fields=dict(Package='federweisser'),
+                id='ffff'),
         ],
         models.DebComponent: [
-            dict(name='main', release='old-stable', id='mainid',
-                 packages=['bbbb', 'cccc', 'dddd', 'ffff']),
-            dict(name='all-only', release='old-stable', id='preid',
-                 packages=['bbbb', 'cccc', 'dddd']),
+            dict(
+                name='main',
+                release='old-stable',
+                id='mainid',
+                packages=['bbbb', 'cccc', 'dddd', 'ffff']),
+            dict(
+                name='all-only',
+                release='old-stable',
+                id='preid',
+                packages=['bbbb', 'cccc', 'dddd']),
         ],
         models.DebRelease: [
             dict(codename='old-stable', id='oldstableid'),
@@ -405,32 +514,45 @@ class TestPublishAllArchCompDeb(PublishRepoMixIn, BaseTest):
 class TestPublishRepoNonAsciiDeb(PublishRepoMixIn, BaseTest):
     Sample_Units = {
         models.DebPackage: [
-            dict(name='gaertner',
-                 source='gärtner',
-                 version='0.1938.0',
-                 installed_size=23,
-                 maintainer='gärtner',
-                 original_maintainer='gärtner',
-                 architecture='amd64',
-                 replaces='gärtner',
-                 provides='gärtner',
-                 depends='gärtner',
-                 pre_depends='gärtner',
-                 recommends='gärtner',
-                 suggests='gärtner',
-                 enhances='gärtner',
-                 conflicts='gärtner',
-                 breaks='gärtner',
-                 description='gärtner',
-                 multi_arch='gärtner',
-                 homepage='gärtner',
-                 section='gärtner',
-                 priority='gärtner',
-                 filename='gärtner',
-                 size=12,
-                 checksum='abcde',
-                 checksumtype='sha3.14',
-                 id='aaaa'),
+            dict(
+                name='gaertner',
+                version='0.1938.0',
+                architecture='amd64',
+                filename='gärtner',
+                size=12,
+                control_fields={
+                    'Source': u'gärtner',
+                    'Version': u'0.1938.0',
+                    'Installed-Size': u'23',
+                    'Maintainer': u'gärtner',
+                    'Original-Maintainer': u'gärtner',
+                    'Architecture': u'amd64',
+                    'Replaces': u'gärtner',
+                    'Provides': u'gärtner',
+                    'Depends': u'gärtner',
+                    'Pre-Depends': u'gärtner',
+                    'Recommends': u'gärtner',
+                    'Suggests': u'gärtner',
+                    'Enhances': u'gärtner',
+                    'Conflicts': u'gärtner',
+                    'Breaks': u'gärtner',
+                    'Description': u'gärtner',
+                    'Multi-Arch': u'gärtner',
+                    'Homepage': u'gärtner',
+                    'Section': u'gärtner',
+                    'Priority': u'gärtner',
+                },
+                source=u'gärtner',
+                maintainer=u'gärtner',
+                installed_size=u'gärtner',
+                section=u'gärtner',
+                priority=u'gärtner',
+                multi_arch=u'gärtner',
+                homepage=u'gärtner',
+                description=u'gärtner',
+                original_maintainer=u'gärtner',
+                id='aaaa',
+            ),
         ],
         models.DebComponent: [
             dict(name='main', release='stable', id='mainid', packages=['aaaa']),
@@ -452,13 +574,27 @@ class TestPublishRepoLayeredComponentDeb(PublishRepoMixIn, BaseTest):
     """
     Sample_Units = {
         models.DebPackage: [
-            dict(name='burgundy', version='0.1938.0', architecture='amd64',
-                 checksum='abcde', checksumtype='sha3.14', id='bbbb'),
-            dict(name='chablis', version='0.2013.0', architecture='all',
-                 checksum='yz', checksumtype='sha3.14', id='cccc'),
+            dict(
+                name='burgundy',
+                version='0.1938.0',
+                architecture='amd64',
+                control_fields=dict(Package='burgundy'),
+                id='bbbb',
+            ),
+            dict(
+                name='chablis',
+                version='0.2013.0',
+                architecture='all',
+                control_fields=dict(Package='chablis'),
+                id='cccc',
+            ),
         ],
         models.DebComponent: [
-            dict(name='updates/main', release='stable', id='mainid', packages=['bbbb', 'cccc']),
+            dict(
+                name='updates/main',
+                release='stable',
+                id='mainid',
+                packages=['bbbb', 'cccc']),
         ],
         models.DebRelease: [
             dict(codename='stable', id='stableid'),

--- a/plugins/test/unit/plugins/distributors/test_distributor.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor.py
@@ -1,9 +1,11 @@
+# -*- coding: utf-8 -*-
 import os
 import shutil
 import sys
 import time
 import uuid
 import hashlib
+import unittest
 
 from debian import deb822
 import mock
@@ -365,6 +367,104 @@ class TestPublishRepoMultiCompArchDeb(PublishRepoMixIn, BaseTest):
         ],
     }
     Architectures = ['all', 'amd64', 'i386', 'ppc']
+    default_release = True
+
+
+@unittest.skip("Skip until https://pulp.plan.io/issues/4094 is fixed!")
+class TestPublishAllArchCompDeb(PublishRepoMixIn, BaseTest):
+    """
+    All packages in component 'all-only' have architecture='all'.
+    The resulting repository should nevertheless contain the 'amd64'
+    architecture for this component.
+    """
+    Sample_Units = {
+        models.DebPackage: [
+            dict(name='burgundy', version='0.1938.0', architecture='all',
+                 checksum='abcde', checksumtype='sha3.14', id='bbbb'),
+            dict(name='chablis', version='0.2013.0', architecture='all',
+                 checksum='yz', checksumtype='sha3.14', id='cccc'),
+            dict(name='dornfelder', version='0.2017.0', architecture='all',
+                 checksum='wxy', checksumtype='sha3.14', id='dddd'),
+            dict(name='federweisser', version='0.2017.0', architecture='amd64',
+                 checksum='foo', checksumtype='sha3.14', id='ffff'),
+        ],
+        models.DebComponent: [
+            dict(name='main', release='old-stable', id='mainid',
+                 packages=['bbbb', 'cccc', 'dddd', 'ffff']),
+            dict(name='all-only', release='old-stable', id='preid',
+                 packages=['bbbb', 'cccc', 'dddd']),
+        ],
+        models.DebRelease: [
+            dict(codename='old-stable', id='oldstableid'),
+        ],
+    }
+    Architectures = ['all', 'amd64']
+    default_release = True
+
+
+class TestPublishRepoNonAsciiDeb(PublishRepoMixIn, BaseTest):
+    Sample_Units = {
+        models.DebPackage: [
+            dict(name='gaertner',
+                 source='gärtner',
+                 version='0.1938.0',
+                 installed_size=23,
+                 maintainer='gärtner',
+                 original_maintainer='gärtner',
+                 architecture='amd64',
+                 replaces='gärtner',
+                 provides='gärtner',
+                 depends='gärtner',
+                 pre_depends='gärtner',
+                 recommends='gärtner',
+                 suggests='gärtner',
+                 enhances='gärtner',
+                 conflicts='gärtner',
+                 breaks='gärtner',
+                 description='gärtner',
+                 multi_arch='gärtner',
+                 homepage='gärtner',
+                 section='gärtner',
+                 priority='gärtner',
+                 filename='gärtner',
+                 size=12,
+                 checksum='abcde',
+                 checksumtype='sha3.14',
+                 id='aaaa'),
+        ],
+        models.DebComponent: [
+            dict(name='main', release='stable', id='mainid', packages=['aaaa']),
+        ],
+        models.DebRelease: [
+            dict(codename='stable', id='stableid'),
+        ],
+    }
+    Architectures = ['all', 'amd64']
+    default_release = False
+
+
+class TestPublishRepoLayeredComponentDeb(PublishRepoMixIn, BaseTest):
+    """
+    Some debian repositories (e.g. debian-security) use additional layers ("/")
+    in the component name as given by the 'Release' file (e.g. component =
+    "updates/main"). This special case has many potential pitfalls and is
+    covered by this test.
+    """
+    Sample_Units = {
+        models.DebPackage: [
+            dict(name='burgundy', version='0.1938.0', architecture='amd64',
+                 checksum='abcde', checksumtype='sha3.14', id='bbbb'),
+            dict(name='chablis', version='0.2013.0', architecture='all',
+                 checksum='yz', checksumtype='sha3.14', id='cccc'),
+        ],
+        models.DebComponent: [
+            dict(name='updates/main', release='stable', id='mainid', packages=['bbbb', 'cccc']),
+        ],
+        models.DebRelease: [
+            dict(codename='stable', id='stableid'),
+        ],
+    }
+    Architectures = ['all', 'amd64']
     default_release = True
 
 

--- a/plugins/test/unit/plugins/distributors/test_distributor.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor.py
@@ -125,13 +125,11 @@ class PublishRepoMixIn(object):
                 pass
         return units
 
-    @mock.patch("pulp_deb.plugins.distributors.distributor.aptrepo.AptRepo.sign")
+    @mock.patch("pulp_deb.plugins.distributors.configuration.signer.Signer.sign")
     @mock.patch('pulp.plugins.util.publish_step.selinux.restorecon')
-    @mock.patch("pulp_deb.plugins.distributors.distributor.aptrepo.debpkg.debfile.DebFile")
     @mock.patch("pulp.server.managers.repo._common.task.current")
     @mock.patch('pulp.plugins.util.publish_step.repo_controller')
-    def test_publish_repo(self, _repo_controller, _task_current, _DebFile,
-                          _restorecon, _sign):
+    def test_publish_repo(self, _repo_controller, _task_current, _restorecon, _sign):
         _task_current.request.id = 'aabb'
         worker_name = "worker01"
         _task_current.request.configure_mock(hostname=worker_name)
@@ -148,12 +146,6 @@ class PublishRepoMixIn(object):
             _l = unit_dict[type_id] = [u for u in units
                                        if u.type_id == type_id]
             unit_counts[type_id] = len(_l)
-
-        debcontrol = _DebFile.return_value.control.debcontrol.return_value
-
-        debcontrol.copy.side_effect = [
-            self._mkdeb(unit_dict[ids.TYPE_ID_DEB][i]) for i in self.Sample_Units_Order
-        ]
 
         distributor = self.Module.DebDistributor()
         repo = mock.Mock()
@@ -301,7 +293,6 @@ class TestPublishOldRepoDeb(PublishRepoMixIn, BaseTest):
         models.DebRelease: [
         ],
     }
-    Sample_Units_Order = [0, 1]
     Architectures = ['all', 'amd64']
     default_release = False
 
@@ -321,7 +312,6 @@ class TestPublishRepoDeb(PublishRepoMixIn, BaseTest):
             dict(codename='stable', id='stableid'),
         ],
     }
-    Sample_Units_Order = [0, 1]
     Architectures = ['all', 'amd64']
     default_release = False
 
@@ -346,7 +336,6 @@ class TestPublishRepoMultiArchDeb(PublishRepoMixIn, BaseTest):
             dict(codename='stable', id='stableid'),
         ],
     }
-    Sample_Units_Order = [2, 3, 0, 1, 3, 3]
     Architectures = ['all', 'amd64', 'i386']
     default_release = False
 
@@ -367,14 +356,14 @@ class TestPublishRepoMultiCompArchDeb(PublishRepoMixIn, BaseTest):
         ],
         models.DebComponent: [
             dict(name='main', release='old-stable', id='mainid',
-                 packages=['bbbb', 'cccc', 'dddd', 'eeee']),
-            dict(name='premature', release='old-stable', id='preid', packages=['ffff']),
+                 packages=['bbbb', 'cccc', 'dddd', 'eeee', 'ffff']),
+            dict(name='premature', release='old-stable', id='preid',
+                 packages=['cccc', 'dddd', 'eeee', 'ffff']),
         ],
         models.DebRelease: [
             dict(codename='old-stable', id='oldstableid'),
         ],
     }
-    Sample_Units_Order = [2, 3, 0, 1, 3, 3, 4, 4, 3, 2, 3, 1, 0, 3, 3]
     Architectures = ['all', 'amd64', 'i386', 'ppc']
     default_release = True
 


### PR DESCRIPTION
This pull request aims to improve the performance of the MetadataStep when dealing with large Debian repositories (e.g. stretch/main). This is achieved by completely removing the debpkgr dependency from this step. The needed functionality is instead implemented directly in pulp_deb.

This pull request is intended as a pure code refactor that does not add or remove any features. (Though I have several ideas for follow on improvements including bug fixes and new features that would be easy to implement on top of these changes). The only "feature changes" I am aware of is that the relative order of fields in both 'Packages' and 'Release' files will have changed (I used the same order I found in upstream Debian Stretch mirrors), and that I no longer write redundant information into 'Release' files (debpkgr would write the codename into various non-codename fields).

I do not (yet) have any systematic benchmarks, but my initial tests suggest that the performance improvement is quite substantial. (I can reliably sync repositories with more than 50000 packages, on a system with 12 GiB of RAM. In the past such repositories have routinely lead to memory allocation failures on systems with 32 GiB of RAM.)

I am happy to answer any questions and would greatly appreciate any feedback so far.