### PR TITLE
Fix test_VerifySignature on devel

### DIFF
--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -237,6 +237,7 @@ SHA256:
     @mock.patch('pulp_deb.plugins.importers.sync.gnupg.GPG')
     def test_VerifySignature(self, _GPG, _DebRelease, _DebComponent):
         key_fpr = '0000111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFF'
+        _GPG.return_value.list_keys.return_value = [dict(fingerprint=key_fpr)]
         step = self.step.children[1]
         self.assertEquals(constants.SYNC_STEP_RELEASE_PARSE, step.step_id)
         step.get_config().repo_plugin_config['require_signature'] = True


### PR DESCRIPTION
The `test_VerifySignature` test will not run on my `devel_pulp2_dev` Vagrant box without this line.
Instead it throws a `raise Exception("No GPG-keys in keyring, did the import fail?")`.
Since Travis appears to be doing fine without this fix, it would be good to know if others are having the same problem, or what the difference between Travis and my local Vagrant box is...

Edit: I added a pulp.plan.io issue to go with this PR:
https://pulp.plan.io/issues/4332