### PR TITLE
Force digest-algo to SHA256

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ rm -f ${1}.gpg
 
 gpg --homedir /var/lib/pulp/gpg-home \
     --batch \
+    --digest-algo SHA256 \
     --detach-sign --default-key $KEYID \
     --armor --output ${1}.gpg ${1}
 ```


### PR DESCRIPTION
Support for keys that state a preference for SHA-1 encryption has been turned off in APT as of Debian 9. (Specifically, it was turned off in APT version 1.4~beta1, and Debian 9 has version 1.4.7.)