### PR TITLE
Ignore invalid paragraphs in package indices

### DIFF
--- a/plugins/pulp_deb/plugins/importers/sync.py
+++ b/plugins/pulp_deb/plugins/importers/sync.py
@@ -272,13 +272,17 @@ class ParsePackagesStep(publish_step.PluginStep):
                     if dlr.url in self.parent.packages_urls[release]])
             for ca in repometa.iter_component_arch_binaries():
                 for pkg in ca.iter_packages():
-                    checksum = pkg['SHA256']
-                    self.parent.unit_relative_urls[checksum] = pkg['Filename']
-                    if checksum in units:
-                        unit = units[checksum]
-                    else:
-                        unit = models.DebPackage.from_packages_paragraph(pkg)
-                        units[checksum] = unit
+                    try:
+                        checksum = pkg['SHA256']
+                        self.parent.unit_relative_urls[checksum] = pkg['Filename']
+                        if checksum in units:
+                            unit = units[checksum]
+                        else:
+                            unit = models.DebPackage.from_packages_paragraph(pkg)
+                            units[checksum] = unit
+                    except KeyError:
+                        _logger.warning(_("Invalid package record found. {}").format(pkg))
+                        continue
                     self.parent.component_packages[release][ca.component].append(unit.unit_key)
         self.parent.available_units = units.values()
 

--- a/plugins/pulp_deb/plugins/importers/sync.py
+++ b/plugins/pulp_deb/plugins/importers/sync.py
@@ -280,7 +280,7 @@ class ParsePackagesStep(publish_step.PluginStep):
                         else:
                             unit = models.DebPackage.from_packages_paragraph(pkg)
                             units[checksum] = unit
-                    except KeyError:
+                    except (KeyError, ValueError):
                         _logger.warning(_("Invalid package record found. {}").format(pkg))
                         continue
                     self.parent.component_packages[release][ca.component].append(unit.unit_key)

--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -114,10 +114,21 @@ SHA256:
                  SHA1="00{0}{0}".format(x),
                  SHA256="00{0}{0}".format(x),
                  Filename="pool/main/{0}_1-1_amd64.deb".format(x))
-            for x in ["a", "b"]]
+            for x in ["a", "b"]
+        ]
+
+        # Add a few invalid entries that should be ignored.
+        invalid_pkgs = [
+            dict(Homepage="http://1234"),
+            dict(Package="c", Version="1.2-3", Architecture="amd64",
+                 MD5sum="00cc", SHA1="00cc", SHA256="00cc"),
+            dict(Package="c", Version="1.2-3",
+                 MD5sum="00cc", SHA1="00cc", SHA256="00cc",
+                 Filename="pool/main/c_1.2-3_amd64.deb"),
+        ]
 
         comp_arch = mock.MagicMock(component='main', arch="amd64")
-        comp_arch.iter_packages.return_value = pkgs
+        comp_arch.iter_packages.return_value = pkgs + invalid_pkgs
 
         repometa.iter_component_arch_binaries.return_value = [comp_arch]
         return pkgs


### PR DESCRIPTION
If the long-description of a package contains an erroneous newline, the
rest of the paragraph is considered to describe a new package, but it is
incomplete. We try to ignore those and hope for the best.
Usually there is only the 'Homepage' field, so no functionality should be
affected.

Thanks to @sbernhard for analysing the problem.