### PR TITLE
Add a "distribution" field

### DIFF
--- a/common/pulp_deb/common/ids.py
+++ b/common/pulp_deb/common/ids.py
@@ -13,12 +13,12 @@ EXTRA_FIELDS_DEB = set([
 
 TYPE_ID_DEB_COMP = 'deb_component'
 UNIT_KEY_DEB_COMP = (
-    'name', 'release', 'repoid')
+    'name', 'distribution', 'repoid')
 EXTRA_FIELDS_DEB_COMP = set([
     'packages'])
 
 TYPE_ID_DEB_RELEASE = 'deb_release'
 UNIT_KEY_DEB_RELEASE = (
-    'codename', 'repoid')
+    'distribution', 'repoid')
 
 SUPPORTED_TYPES = set([TYPE_ID_DEB, TYPE_ID_DEB_COMP, TYPE_ID_DEB_RELEASE])

--- a/extensions_admin/pulp_deb/extensions/admin/units_display.py
+++ b/extensions_admin/pulp_deb/extensions/admin/units_display.py
@@ -47,7 +47,7 @@ def _details_release(release):
     :return: The display string of the release
     :rtype: str
     """
-    return '%s' % (release['codename'])
+    return '%s' % (release['distribution'])
 
 
 def _details_component(component):

--- a/plugins/pulp_deb/plugins/migrations/0004_add_distribution.py
+++ b/plugins/pulp_deb/plugins/migrations/0004_add_distribution.py
@@ -1,0 +1,137 @@
+import logging
+from pulp.server.db import connection
+from pulp_deb.common import ids
+from pymongo.errors import OperationFailure
+
+_logger = logging.getLogger(__name__)
+
+
+def prepare_reindex_migration(*args, **kwargs):
+    """
+    Add a naive distribution field to both deb releases and components, to
+    ensure we will survive uniqueness constraints post index creation.
+    """
+    release_collection = connection.get_collection('units_deb_release')
+    component_collection = connection.get_collection('units_deb_component')
+
+    unit_filter = {'distribution': {'$exists': False}}
+
+    # Migrate the units_deb_release collection:
+    for release in release_collection.find(unit_filter, ['codename']).batch_size(100):
+        new_release_fields = {
+            'distribution': release['codename'],
+        }
+
+        release_collection.update_one(
+            {'_id': release['_id']},
+            {'$set': new_release_fields},
+        )
+
+    # Migrate the units_deb_component collection:
+    for component in component_collection.find(unit_filter, ['release']).batch_size(100):
+        new_component_fields = {
+            'distribution': component['release'],
+        }
+
+        component_collection.update_one(
+            {'_id': component['_id']},
+            {'$set': new_component_fields},
+        )
+
+
+def migrate(*args, **kwargs):
+    """
+    Provide a best effort migration for the previously added naive distribution
+    fields for both deb releases and components.
+    """
+    warnings_encountered = False
+    release_collection = connection.get_collection('units_deb_release')
+    component_collection = connection.get_collection('units_deb_component')
+    importer_collection = connection.get_collection('repo_importers')
+
+    # If they exist, drop the old uniqueness constraints:
+    try:
+        release_collection.drop_index("codename_1_repoid_1")
+        component_collection.drop_index("name_1_release_1_repoid_1")
+    except OperationFailure as exception:
+        _logger.log(str(exception))
+
+    deb_importer_filter = {'importer_type_id': ids.TYPE_ID_IMPORTER}
+
+    # Perform a best effort to recreate the upstream distribution:
+    for repo_importer in importer_collection.find(deb_importer_filter).batch_size(100):
+        distributions = repo_importer['config']['releases'].split(',')
+
+        release_filter = {'repoid': repo_importer['repo_id']}
+
+        for release in release_collection.find(release_filter).batch_size(100):
+            original_distribution = None
+            if release['codename'] in distributions:
+                continue
+            elif release['suite'] in distributions:
+                original_distribution = release['suite']
+
+            component_filter = {
+                'repoid': repo_importer['repo_id'],
+                'release': release['codename'],
+            }
+
+            prefix = None
+            for component in component_collection.find(component_filter).batch_size(100):
+                plain_component = None
+                if prefix:
+                    # never the case in the first iteration
+                    plain_component = component['name'].strip('/').split('/')[-1]
+                    if prefix != '/'.join(component['name'].strip('/').split('/')[:-1]):
+                        warnings_encountered = True
+                        msg = 'Encountered component unit with inconsistent prefix!\n'\
+                              '_id = {}\n'\
+                              'The unit was not migrated!'.format(component['_id'])
+                        _logger.warn(msg)
+                        continue
+                    new_component_fields = {
+                        'name': plain_component,
+                        'distribution': original_distribution,
+                    }
+                    component_collection.update_one(
+                        {'_id': component['_id']},
+                        {'$set': new_component_fields},
+                    )
+                elif original_distribution:
+                    new_component_fields = {'distribution': original_distribution}
+                    component_collection.update_one(
+                        {'_id': component['_id']},
+                        {'$set': new_component_fields},
+                    )
+                elif '/' in component['name']:
+                    # only possible in the first iteration
+                    plain_component = component['name'].strip('/').split('/')[-1]
+                    prefix = '/'.join(component['name'].strip('/').split('/')[:-1])
+
+                    if release['codename'] + '/' + prefix in distributions:
+                        original_distribution = release['codename'] + '/' + prefix
+                    elif release['suite'] + '/' + prefix in distributions:
+                        original_distribution = release['suite'] + '/' + prefix
+                    else:
+                        # The approach did not work, out of ideas!
+                        break
+
+                    new_component_fields = {
+                        'name': plain_component,
+                        'distribution': original_distribution,
+                    }
+                    component_collection.update_one(
+                        {'_id': component['_id']},
+                        {'$set': new_component_fields},
+                    )
+
+            new_release_fields = {'distribution': original_distribution}
+            release_collection.update_one(
+                {'_id': release['_id']},
+                {'$set': new_release_fields},
+            )
+
+    if warnings_encountered:
+        msg = 'Warnings were encountered during the db migration!\n'\
+              'Check the logs for more information, and consider deleting broken units.'
+        _logger.warn(msg)

--- a/plugins/test/unit/plugins/distributors/test_distributor.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor.py
@@ -290,7 +290,7 @@ class PublishRepoMixIn(object):
 
         for release in unit_dict[ids.TYPE_ID_DEB_RELEASE]:
             work_release_file = os.path.join(self.pulp_working_dir, worker_name,
-                                             "aabb", "dists", release.codename, "Release")
+                                             "aabb", "dists", release.distribution, "Release")
             _sign.assert_any_call(work_release_file)
 
     @classmethod
@@ -356,6 +356,45 @@ class TestPublishRepoDeb(PublishRepoMixIn, BaseTest):
         models.DebRelease: [
             dict(
                 distribution='stable',
+                codename='stable',
+                id='stableid',
+            ),
+        ],
+    }
+    Architectures = ['all', 'amd64']
+    default_release = False
+
+
+class TestPublishRepoDebNestedDistribution(PublishRepoMixIn, BaseTest):
+    Sample_Units = {
+        models.DebPackage: [
+            dict(
+                name='burgundy',
+                version='0.1938.0',
+                architecture='amd64',
+                control_fields=dict(Package='burgundy'),
+                id='bbbb',
+            ),
+            dict(
+                name='chablis',
+                version='0.2013.0',
+                architecture='amd64',
+                control_fields=dict(Package='chablis'),
+                id='cccc',
+            ),
+        ],
+        models.DebComponent: [
+            dict(
+                name='main',
+                distribution='stable/updates',
+                release='stable',
+                id='mainid',
+                packages=['bbbb', 'cccc']
+            ),
+        ],
+        models.DebRelease: [
+            dict(
+                distribution='stable/updates',
                 codename='stable',
                 id='stableid',
             ),

--- a/plugins/types/deb.json
+++ b/plugins/types/deb.json
@@ -11,14 +11,14 @@
         "id": "deb_component",
         "display_name": "DEB_COMP",
         "description": "Deb Release Component",
-        "unit_key": ["name", "release", "repoid"],
+        "unit_key": ["name", "distribution", "repoid"],
         "search_indexes": []
     },
     {
         "id": "deb_release",
         "display_name": "DEB_RELEASE",
         "description": "Deb Release",
-        "unit_key": ["codename", "repoid"],
+        "unit_key": ["distribution", "repoid"],
         "search_indexes": []
     }
 ]}


### PR DESCRIPTION
**DEPENDS ON:** https://github.com/pulp/pulp/pull/3919 (https://pulp.plan.io/issues/4871)
**Fixes**:
- https://pulp.plan.io/issues/4138
- https://pulp.plan.io/issues/4705
- https://pulp.plan.io/issues/4707

**Relates to**:
- https://pulp.plan.io/issues/3464 (fixes it in pulp, but also needs to be fixed in `python-debpkgr`)

**Background**

Debian repositories are generally structured into multiple "releases" or "distributions", each associated with a single "Release" file somewhere within the `/dists/` folder of the repository.

Most commonly such release files are placed within the folder in one of two ways:

    /dists/<codename>/Release
    /dists/<suite>/Release

Pulp currently publishes all `Release` files under the `<codename>` path.

However, the official specification allows for the following structure:

    /dists/<distribution>/Release

where `<distribution>` may include an arbitrary number of folder levels, and may differ from both `codename` and `suite`.

This leads to a whole class of unpredictable (read undesirable or buggy) behavior within pulp whenever upstream repositories use a `<distribution> != <codename>`.

**This Fix**

This fix aims to conclusively solve all related problems by introuducing internal "distribution" fields.
This field is then used instead of "codename" wherever relevant.