### PR TITLE
Make pulp_deb publish empty repositories.

### DIFF
--- a/plugins/pulp_deb/plugins/distributors/distributor.py
+++ b/plugins/pulp_deb/plugins/distributors/distributor.py
@@ -290,10 +290,6 @@ class MetadataStep(PluginStep):
         config = self.get_config()
         base_path = self.get_working_dir()
 
-        # Do nothing, if the repository is empty (review this behaviour):
-        if len(unit_dict) == 0:
-            return
-
         # If there are no release_units (old style repo) publish as 'stable/main':
         if len(release_units) == 0:
             default_release = models.DebRelease(

--- a/plugins/test/unit/plugins/distributors/test_distributor.py
+++ b/plugins/test/unit/plugins/distributors/test_distributor.py
@@ -538,6 +538,34 @@ class TestPublishRepoMultiCompArchDeb(PublishRepoMixIn, BaseTest):
     packages_file_count = 12
 
 
+class TestPublishEmptyRepo(PublishRepoMixIn, BaseTest):
+    """
+    Empty repositories (no packages) should still publish a valid Release file
+    allong with empty Packages files.
+    """
+    Sample_Units = {
+        models.DebPackage: [],
+        models.DebComponent: [
+            dict(
+                name='main',
+                distribution='stable',
+                id='mainid',
+            ),
+        ],
+        models.DebRelease: [
+            dict(
+                distribution='stable',
+                codename='stable',
+                id='stableid',
+            ),
+        ],
+    }
+    Architectures = ['all']
+    default_release = False
+    release_file_count = 1
+    packages_file_count = 1
+
+
 @unittest.skip("Skip until https://pulp.plan.io/issues/4094 is fixed!")
 class TestPublishAllArchCompDeb(PublishRepoMixIn, BaseTest):
     """


### PR DESCRIPTION
fixes #4345
https://pulp.plan.io/issues/4345

The current behavior of pulp_deb is not to publish anything if repositories are empty (contain no packages).

This prevents pulp to pulp syncs and may be a problem for clients configured to use a repository with an empty publish directory.

By simply removing a guard the publish mechanism works as expected producing a valid empty repository complete with Release and (empty) Packages file.

The only limitation is that because of https://pulp.plan.io/issues/4094 the only architecture that will be published is the `all` architecture. However, this can be fixed as a separate issue.