### PR TITLE
Add validation of existing packages to sync

### DIFF
--- a/common/pulp_deb/common/constants.py
+++ b/common/pulp_deb/common/constants.py
@@ -25,6 +25,7 @@ CONFIG_GPG_KEYS = 'gpg_keys'
 CONFIG_ALLOWED_KEYS = 'allowed_keys'
 CONFIG_KEYSERVER = 'keyserver'
 CONFIG_KEYSERVER_DEFAULT = 'hkp://wwwkeys.pgp.net'
+CONFIG_REPAIR_SYNC = 'repair_sync'
 
 # Distributor configuration key names
 CONFIG_SERVE_HTTP = 'serve_http'

--- a/plugins/pulp_deb/plugins/db/models.py
+++ b/plugins/pulp_deb/plugins/db/models.py
@@ -285,7 +285,7 @@ class DebPackage(FileContentUnit):
             repository=repo, unit=self)
         return self
 
-    def save_and_associate(self, file_path, repo):
+    def save_and_associate(self, file_path, repo, force=False):
         filename = self.filename_from_unit_key(self.unit_key)
         self.set_storage_path(filename)
         unit = self
@@ -294,6 +294,8 @@ class DebPackage(FileContentUnit):
             self.safe_import_content(file_path)
         except NotUniqueError:
             unit = self.__class__.objects.filter(**unit.unit_key).first()
+            if force:
+                self.import_content(file_path)
         unit.associate(repo)
         return unit
 

--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -18,6 +18,7 @@ from pulp_deb.plugins.importers import sync
 class _TestSyncBase(testbase.TestCase):
     remove_missing = False
     release = None
+    repair_sync = False
 
     def setUp(self):
         super(_TestSyncBase, self).setUp()
@@ -33,6 +34,7 @@ class _TestSyncBase(testbase.TestCase):
             importer_constants.KEY_FEED: 'http://example.com/deb',
             constants.CONFIG_REQUIRE_SIGNATURE: False,
             importer_constants.KEY_UNITS_REMOVE_MISSING: self.remove_missing,
+            constants.CONFIG_REPAIR_SYNC: self.repair_sync,
         }
         if self.release:
             plugin_config['releases'] = self.release
@@ -230,7 +232,7 @@ SHA256:
 
         repo = self.repo.repo_obj
         for path, unit in path_to_unit.items():
-            unit.save_and_associate.assert_called_once_with(path, repo)
+            unit.save_and_associate.assert_called_once_with(path, repo, force=self.repair_sync)
 
     def test_SaveDownloadedUnits_bad_sha256(self):
         self.repo.repo_obj = mock.MagicMock(repo_id=self.repo.id)
@@ -313,3 +315,7 @@ class TestSyncRemoveMissing(_TestSyncBase):
 
 class TestSyncNestedDistribution(_TestSyncBase):
     release = 'stable/updates'
+
+
+class TestSyncRepairSync(_TestSyncBase):
+    repair_sync = True


### PR DESCRIPTION
If force full mode is active, existing packages are validated and if needed
rescheduled for download.

closes #5170
https://pulp.plan.io/issues/5170