### PR TITLE
Rename fields on Serializers

### DIFF
--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -63,8 +63,7 @@ class GenericContentSerializer(SingleArtifactContentSerializer, ContentChecksumS
         """Validate the GenericContent data."""
         data = super().validate(data)
 
-        data["sha256"] = data["_artifact"].sha256
-        data["_relative_path"] = data["relative_path"]
+        data["sha256"] = data["artifact"].sha256
 
         content = GenericContent.objects.filter(
             sha256=data["sha256"], relative_path=data["relative_path"]
@@ -81,11 +80,7 @@ class GenericContentSerializer(SingleArtifactContentSerializer, ContentChecksumS
         return data
 
     class Meta:
-        fields = (
-            tuple(set(SingleArtifactContentSerializer.Meta.fields) - {"_relative_path"})
-            + ContentChecksumSerializer.Meta.fields
-            + ("relative_path",)
-        )
+        fields = SingleArtifactContentSerializer.Meta.fields + ContentChecksumSerializer.Meta.fields
         model = GenericContent
 
 
@@ -190,8 +185,6 @@ class PackageSerializer(SingleArtifactContentSerializer):
 
     build_essential = YesNoField(required=False)
 
-    relative_path = CharField(help_text="Path of file relative to url.", required=False)
-
     class Meta:
         fields = SingleArtifactContentSerializer.Meta.fields + (
             "package_name",
@@ -223,7 +216,6 @@ class PackageSerializer(SingleArtifactContentSerializer):
             "pre_depends",
             "provides",
             "replaces",
-            "relative_path",
             "sha256",
         )
         model = Package
@@ -238,8 +230,6 @@ class InstallerPackageSerializer(SingleArtifactContentSerializer):
 
     build_essential = YesNoField(required=False)
 
-    relative_path = CharField(help_text="Path of file relative to url.", required=False)
-
     class Meta:
         fields = SingleArtifactContentSerializer.Meta.fields + (
             "package_name",
@@ -271,7 +261,6 @@ class InstallerPackageSerializer(SingleArtifactContentSerializer):
             "pre_depends",
             "provides",
             "replaces",
-            "relative_path",
             "sha256",
         )
         model = InstallerPackage

--- a/pulp_deb/tests/functional/utils.py
+++ b/pulp_deb/tests/functional/utils.py
@@ -109,7 +109,7 @@ def gen_deb_generic_content_attrs(artifact):
     :param: artifact: A dict of info about the artifact.
     :returns: A semi-random dict for use in creating a content unit.
     """
-    return {"_artifact": artifact["_href"], "relative_path": DEB_GENERIC_CONTENT_RELPATH}
+    return {"artifact": artifact["_href"], "relative_path": DEB_GENERIC_CONTENT_RELPATH}
 
 
 def populate_pulp(cfg, url=DEB_FIXTURE_URL):


### PR DESCRIPTION
The fields _artifact and _relative_path on the SingleArtifactSerializer
have been renamed to artifact and relative_path.

[noissue]