### PR TITLE
Use the PULP_FIXTRUES_BASE_URL from config

### DIFF
--- a/pulp_deb/tests/functional/api/test_download_policies.py
+++ b/pulp_deb/tests/functional/api/test_download_policies.py
@@ -182,7 +182,7 @@ class SwitchDownloadPolicyTestCase(unittest.TestCase):
 
     def test_all(self):
         """Perform a lazy sync and change to immeditae to force download."""
-        NON_LAZY_ARTIFACT_COUNT = 11
+        NON_LAZY_ARTIFACT_COUNT = 13
         cfg = config.get_config()
         # delete orphans to assure that no content units are present on the
         # file system

--- a/pulp_deb/tests/functional/constants.py
+++ b/pulp_deb/tests/functional/constants.py
@@ -2,7 +2,7 @@
 """Constants for Pulp Deb plugin tests."""
 from urllib.parse import urljoin
 
-from pulp_smash.constants import PULP_FIXTURES_BASE_URL
+from pulp_smash import config
 from pulp_smash.pulp3.constants import (
     # API_DOCS_PATH,
     BASE_CONTENT_PATH,
@@ -17,6 +17,8 @@ from pulp_smash.pulp3.constants import (
 def _clean_dict(d):
     return {k: v for k, v in d.items() if v != 0}
 
+
+PULP_FIXTURES_BASE_URL = config.get_config().get_fixtures_url()
 
 DOWNLOAD_POLICIES = ["immediate", "streamed", "on_demand"]
 


### PR DESCRIPTION
This has so far prevented the use of the fixtures container for Travis tests.

Depends on https://github.com/pulp/pulp-fixtures/pull/145