### PR TITLE
Add sync tests for invalid Debian fixtures

### DIFF
--- a/CHANGES/6052.misc
+++ b/CHANGES/6052.misc
@@ -1,0 +1,1 @@
+Added tests for invalid Debian repositories (bad signature and, missing Package indecies)

--- a/pulp_deb/tests/functional/constants.py
+++ b/pulp_deb/tests/functional/constants.py
@@ -90,8 +90,7 @@ DEB_PACKAGE_URL = urljoin(DEB_FIXTURE_URL, DEB_PACKAGE_RELPATH)
 DEB_GENERIC_CONTENT_RELPATH = "dists/ragnarok/asgard/binary-armeb/Release"
 DEB_GENERIC_CONTENT_URL = urljoin(DEB_FIXTURE_URL, DEB_GENERIC_CONTENT_RELPATH)
 
-# FIXME: replace this with your own fixture repository URL and metadata
-DEB_INVALID_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "deb_invalid/")
+DEB_INVALID_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "debian-invalid/")
 
 # FIXME: replace this with your own fixture repository URL and metadata
 DEB_LARGE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "deb_large/")


### PR DESCRIPTION
Depends on https://github.com/pulp/pulp-fixtures/pull/147

ref #6052
https://pulp.plan.io/issues/6052

Has been fully tested with a local build of the pulp-fixtures container.