### PR TITLE
Prepare 2.3.0b1 (beta) release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,52 @@ Changelog
 
 .. towncrier release notes start
 
+2.3.0b1 (2020-04-29)
+====================
+
+Features
+--------
+
+
+- Added Release file signing using signing services.
+  `#6171 <https://pulp.plan.io/issues/6171>`_
+
+
+
+Bugfixes
+--------
+
+
+- Fixed synchronization of Release files without a Suite field.
+  `#6050 <https://pulp.plan.io/issues/6050>`_
+- Fixed publication creation with packages referenced from multiple package inecies.
+  `#6383 <https://pulp.plan.io/issues/6383>`_
+
+
+
+Improved Documentation
+----------------------
+
+
+- Documented bindings installation for the dev environment.
+  `#6396 <https://pulp.plan.io/issues/6396>`_
+
+
+
+Misc
+----
+
+
+- Added tests for invalid Debian repositories (bad signature, missing package indecies).
+  `#6052 <https://pulp.plan.io/issues/6052>`_
+- Made tests use the bindings config from pulp-smash.
+  `#6393 <https://pulp.plan.io/issues/6393>`_
+
+
+
+----
+
+
 2.2.0b1 (2020-03-03)
 ====================
 

--- a/CHANGES/6050.bugfix
+++ b/CHANGES/6050.bugfix
@@ -1,1 +1,0 @@
-Fixed a bug preventing synchronization of Release files without a Suite field.

--- a/CHANGES/6052.misc
+++ b/CHANGES/6052.misc
@@ -1,1 +1,0 @@
-Added tests for invalid Debian repositories (bad signature and, missing Package indecies)

--- a/CHANGES/6171.feature
+++ b/CHANGES/6171.feature
@@ -1,1 +1,0 @@
-Add support for signing release files

--- a/CHANGES/6383.bugfix
+++ b/CHANGES/6383.bugfix
@@ -1,1 +1,0 @@
-Fixed a bug preventing publication of repositories that include the same package in multiple Packages files.

--- a/CHANGES/6393.misc
+++ b/CHANGES/6393.misc
@@ -1,1 +1,0 @@
-Get bindings config from pulp-smash

--- a/CHANGES/6396.doc
+++ b/CHANGES/6396.doc
@@ -1,1 +1,0 @@
-Documented bindings installation on dev environment

--- a/pulp_deb/__init__.py
+++ b/pulp_deb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.3.0b1.dev"
+__version__ = "2.3.0b1"
 
 default_app_config = "pulp_deb.app.PulpDebPluginAppConfig"

--- a/pulp_deb/__init__.py
+++ b/pulp_deb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.3.0b1"
+__version__ = "2.4.0b1.dev"
 
 default_app_config = "pulp_deb.app.PulpDebPluginAppConfig"

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "pulpcore>=3.3,<3.4",
+    "pulpcore>=3.3",
     "python-debian>=0.1.36",
 ]
 
 setup(
     name="pulp-deb",
-    version="2.3.0b1",
+    version="2.4.0b1.dev",
     description="pulp-deb plugin for the Pulp Project",
     license="GPLv2+",
     author="Matthias Dellweg",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@
 
 from setuptools import find_packages, setup
 
-requirements = ["pulpcore>=3.3.0.dev", "python-debian>=0.1.36"]
+requirements = [
+    "pulpcore>=3.3.0.dev",
+    "python-debian>=0.1.36",
+]
 
 setup(
     name="pulp-deb",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
 
 setup(
     name="pulp-deb",
-    version="2.3.0b1.dev",
+    version="2.3.0b1",
     description="pulp-deb plugin for the Pulp Project",
     license="GPLv2+",
     author="Matthias Dellweg",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "pulpcore>=3.3.0.dev",
+    "pulpcore>=3.3,<3.4",
     "python-debian>=0.1.36",
 ]
 


### PR DESCRIPTION
I have prepared this PR for creating a `pulp_deb` `2.3.0b1` beta release, compatible to pulpcore `2.3`.

I believe I do not have the required permissions to actually create this beta release, which is why this is a "Draft pull request".

If I have understood everything correctly, I need someone to do the following in order to create the Release:

1. Review these changes
1. Create a branch named `2.3` at commit 662daab and push it to `pulp/pulp_deb`
1. Create a tag named `2.3.0b1` at the same commit and push it to `pulp/pulp_deb`
1. Check if the pipeline successfully released to https://pypi.org/project/pulp-deb/
1. Merge this PR