### PR TITLE
Add per repository package uniqueness constraints

### DIFF
--- a/CHANGES/6429.doc
+++ b/CHANGES/6429.doc
@@ -1,0 +1,1 @@
+Added a note on per repository package uniqueness constraints to the feature overview documentation.

--- a/CHANGES/6429.feature
+++ b/CHANGES/6429.feature
@@ -1,0 +1,1 @@
+Added handling of packages with the same name, version, and architecture, when saving a new repository version.

--- a/docs/feature_overview.rst
+++ b/docs/feature_overview.rst
@@ -89,6 +89,14 @@ In general, uploading content works the same way as for any other Pulp plugin, s
    As a result, manually uploaded packages will only show up in your publications, if you are using the "simple" publisher.
    For more information, see :ref:`simple and structured publishing <simple_and_structured_publishing>` below.
 
+.. note::
+   As a matter of best practice, the existence of multiple Debian packages with the same name, version, and architecture (but different content/checksum) should be avoided.
+   Since the existence of such packages may be beyond the control of the ``pulp_deb`` user, the plugin takes a maximally permissive approach:
+   Users can upload arbitrary (valid) packages to the Pulp database, but they cannot add multiple colliding packages of the same type (``.deb`` or ``.udeb``), to a single Pulp repository version.
+   If users attempt to add one or more packages to a Pulp repository, and there are collisions with packages from the previous repository version, then the older packages will automatically be removed.
+   If there are still collisions in the new repository version, an error is thrown and the task will fail.
+   (This latter case can only happen if users attempt to add several colliding packages in a single API call.)
+
 
 .. _simple_and_structured_publishing:
 

--- a/pulp_deb/app/models/content.py
+++ b/pulp_deb/app/models/content.py
@@ -203,6 +203,8 @@ class BasePackage(Content):
             "{}.{}".format(self.name, self.SUFFIX),
         )
 
+    repo_key_fields = ("package", "version", "architecture")
+
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
         unique_together = (("relative_path", "sha256"),)

--- a/pulp_deb/app/models/repository.py
+++ b/pulp_deb/app/models/repository.py
@@ -2,6 +2,8 @@ from logging import getLogger
 
 from pulpcore.plugin.models import Repository
 
+from pulpcore.plugin.repo_version_utils import remove_duplicates, validate_repo_version
+
 from pulp_deb.app.models import (
     GenericContent,
     ReleaseFile,
@@ -39,3 +41,17 @@ class AptRepository(Repository):
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
+
+    def finalize_new_version(self, new_version):
+        """
+        Finalize and validate the new repository version.
+
+        Ensure there are no duplication of added package in debian repository.
+
+        Args:
+            new_version (pulpcore.app.models.RepositoryVersion): The incomplete RepositoryVersion to
+                finalize.
+
+        """
+        remove_duplicates(new_version)
+        validate_repo_version(new_version)


### PR DESCRIPTION
Add uniqueness constraint for debian repository versions such that there are no duplicate packages in repository.

fixes #6429
https://pulp.plan.io/issues/6429