### PR TITLE
Fix structured publishing

### DIFF
--- a/CHANGES/6787.bugfix
+++ b/CHANGES/6787.bugfix
@@ -1,0 +1,1 @@
+Fixed structured publishing of architecture 'all' type packages.

--- a/pulp_deb/app/tasks/publishing.py
+++ b/pulp_deb/app/tasks/publishing.py
@@ -171,8 +171,14 @@ class _ComponentHelper:
         )
         published_artifact.save()
         package_serializer = Package822Serializer(package, context={"request": None})
-        package_serializer.to822(self.name).dump(self.package_index_files[package.architecture][0])
-        self.package_index_files[package.architecture][0].write(b"\n")
+        deb822_package = package_serializer.to822(self.name)
+        if package.architecture == "all":
+            for index_file in self.package_index_files.values():
+                deb822_package.dump(index_file[0])
+                index_file[0].write(b"\n")
+        else:
+            deb822_package.dump(self.package_index_files[package.architecture][0])
+            self.package_index_files[package.architecture][0].write(b"\n")
 
     def finish(self):
         # Publish Packages files


### PR DESCRIPTION
fixes #6787
https://pulp.plan.io/issues/6787

Ensures packages with architecture 'all' are added to all available
package indecies, rather than a non existent 'all' package index.

Note: I believe we can create test coverage for this change, by simply adding some `architecture=all` type packages to the existing fixture repos. I will open a separate PR against https://github.com/pulp/pulp-fixtures