### PR TITLE
Use the correct relative paths in Release files

### DIFF
--- a/CHANGES/6876.bugfix
+++ b/CHANGES/6876.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where published Release files were using paths relative to the repo root, instead of relative to the release file.

--- a/pulp_deb/app/tasks/publishing.py
+++ b/pulp_deb/app/tasks/publishing.py
@@ -251,7 +251,7 @@ class _ReleaseHelper:
         for component in self.components.values():
             component.finish()
         # Publish Release file
-        self.release["components"] = " ".join(self.components.keys())
+        self.release["Components"] = " ".join(self.components.keys())
         release_dir = os.path.join("dists", self.distribution)
         release_path = os.path.join(release_dir, "Release")
         os.makedirs(os.path.dirname(release_path), exist_ok=True)


### PR DESCRIPTION
fixes #6876
https://pulp.plan.io/issues/6876

I also fixed several instances of using the codename in paths. Codenames
should never be used in paths. Always use the "distribution" in paths.

ref #6051
https://pulp.plan.io/issues/6051