### PR TITLE
Prepare release 2.4.0b1 (beta)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,32 @@ Changelog
 
 .. towncrier release notes start
 
+2.4.0b1 (2020-06-17)
+====================
+
+Features
+--------
+
+
+- The "Date" field is now added to Release files during publish.
+  `#6869 <https://pulp.plan.io/issues/6869>`_
+
+
+
+Bugfixes
+--------
+
+
+- Fixed structured publishing of architecture 'all' type packages.
+  `#6787 <https://pulp.plan.io/issues/6787>`_
+- Fixed a bug where published Release files were using paths relative to the repo root, instead of relative to the release file.
+  `#6876 <https://pulp.plan.io/issues/6876>`_
+
+
+
+----
+
+
 2.3.0b1 (2020-04-29)
 ====================
 

--- a/CHANGES/6787.bugfix
+++ b/CHANGES/6787.bugfix
@@ -1,1 +1,0 @@
-Fixed structured publishing of architecture 'all' type packages.

--- a/CHANGES/6869.feature
+++ b/CHANGES/6869.feature
@@ -1,1 +1,0 @@
-The "Date" field is now added to Release files during publish.

--- a/CHANGES/6876.bugfix
+++ b/CHANGES/6876.bugfix
@@ -1,1 +1,0 @@
-Fixed a bug where published Release files were using paths relative to the repo root, instead of relative to the release file.

--- a/pulp_deb/__init__.py
+++ b/pulp_deb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.4.0b1.dev"
+__version__ = "2.4.0b1"
 
 default_app_config = "pulp_deb.app.PulpDebPluginAppConfig"

--- a/pulp_deb/__init__.py
+++ b/pulp_deb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.4.0b1"
+__version__ = "2.5.0b1.dev"
 
 default_app_config = "pulp_deb.app.PulpDebPluginAppConfig"

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "pulpcore>=3.3",
+    "pulpcore>=3.4,<3.5",
     "python-debian>=0.1.36",
 ]
 
 setup(
     name="pulp-deb",
-    version="2.4.0b1.dev",
+    version="2.4.0b1",
     description="pulp-deb plugin for the Pulp Project",
     license="GPLv2+",
     author="Matthias Dellweg",

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "pulpcore>=3.4,<3.5",
+    "pulpcore>=3.4",
     "python-debian>=0.1.36",
 ]
 
 setup(
     name="pulp-deb",
-    version="2.4.0b1",
+    version="2.5.0b1.dev",
     description="pulp-deb plugin for the Pulp Project",
     license="GPLv2+",
     author="Matthias Dellweg",


### PR DESCRIPTION
This is mainly needed so people can install the plugin along with pulpcore `3.4`.

This nevertheless remains a beta release!