### PR TITLE
Fix APT client installing patches

### DIFF
--- a/CHANGES/6982.bugfix
+++ b/CHANGES/6982.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where APT client was installing same patches again and again.

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -202,7 +202,7 @@ class BasePackage822Serializer(SingleArtifactContentSerializer):
         "bugs": "Bugs",
         "essential": "Essential",
         "build_essential": "Build_essential",
-        "installed_size": "Installed_size",
+        "installed_size": "Installed-Size",
         "maintainer": "Maintainer",
         "original_maintainer": "Original_Maintainer",
         "description": "Description",


### PR DESCRIPTION
fixes APT client installing same packages again and again due to missing installed_size.

fixes #6982
https://pulp.plan.io/issues/6982