### PR TITLE
Do not sync repository with bad remote repository

### DIFF
--- a/CHANGES/6948.bugfix
+++ b/CHANGES/6948.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug to prevent the repository to sync with bad remote repository which has non-existing components or architectures.

--- a/pulp_deb/tests/functional/api/test_sync.py
+++ b/pulp_deb/tests/functional/api/test_sync.py
@@ -192,6 +192,26 @@ class SyncInvalidTestCase(unittest.TestCase):
         self.assertIn("No suitable Package index file", error["description"])
         self.assertIn("armeb", error["description"])
 
+    def test_invalid_architecture(self):
+        """Sync a repository using a architecture that does not exist.
+
+        Test that we get a task failure. See :meth:`do_test`.
+        """
+        with self.assertRaises(PulpTaskError) as exc:
+            self.do_test(url=DEB_FIXTURE_URL, architectures="no_arch")
+        error = exc.exception.task.error
+        self.assertIn("No valid attribute", error["description"])
+
+    def test_invalid_component(self):
+        """Sync a repository using a component that does not exist.
+
+        Test that we get a task failure. See :meth:`do_test`.
+        """
+        with self.assertRaises(PulpTaskError) as exc:
+            self.do_test(url=DEB_FIXTURE_URL, components="no_comp")
+        error = exc.exception.task.error
+        self.assertIn("No valid attribute", error["description"])
+
     def test_invalid_signature(self):
         """Sync a repository with an invalid signature.
 


### PR DESCRIPTION
Do not sync repository with bad remote repository that has non-existing components or architectures.

fixes #6948
https://pulp.plan.io/issues/6948,