### PR TITLE
 Prepare the 2.5.0b1 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,41 @@ Changelog
 
 .. towncrier release notes start
 
+2.5.0b1 (2020-07-15)
+====================
+
+Features
+--------
+
+
+- Added additional metadata fields to published Release files.
+  `#6907 <https://pulp.plan.io/issues/6907>`_
+
+
+
+Bugfixes
+--------
+
+
+- Fixed a bug where some nullable fields for remotes could not be set to null via the API.
+  `#6908 <https://pulp.plan.io/issues/6908>`_
+- Fixed a bug where APT client was installing same patches again and again.
+  `#6982 <https://pulp.plan.io/issues/6982>`_
+
+
+
+Misc
+----
+
+
+- Renamed some internal models to Apt.. to keep API consistent with other plugins.
+  `#6897 <https://pulp.plan.io/issues/6897>`_
+
+
+
+----
+
+
 2.4.0b1 (2020-06-17)
 ====================
 

--- a/CHANGES/6897.misc
+++ b/CHANGES/6897.misc
@@ -1,1 +1,0 @@
-Renamed some internal models to Apt.. to keep API consistent with other plugins.

--- a/CHANGES/6907.feature
+++ b/CHANGES/6907.feature
@@ -1,1 +1,0 @@
-Added additional metadata fields to published Release files.

--- a/CHANGES/6908.bugfix
+++ b/CHANGES/6908.bugfix
@@ -1,1 +1,0 @@
-Fixed a bug where some nullable fields for remotes could not be set to null via the API.

--- a/CHANGES/6982.bugfix
+++ b/CHANGES/6982.bugfix
@@ -1,1 +1,0 @@
-Fixed a bug where APT client was installing same patches again and again.

--- a/pulp_deb/__init__.py
+++ b/pulp_deb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.5.0b1.dev"
+__version__ = "2.5.0b1"
 
 default_app_config = "pulp_deb.app.PulpDebPluginAppConfig"

--- a/pulp_deb/__init__.py
+++ b/pulp_deb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.5.0b1"
+__version__ = "2.6.0b1.dev"
 
 default_app_config = "pulp_deb.app.PulpDebPluginAppConfig"

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "pulpcore>=3.5,<3.6",
+    "pulpcore>=3.5",
     "python-debian>=0.1.36",
 ]
 
 setup(
     name="pulp-deb",
-    version="2.5.0b1",
+    version="2.6.0b1.dev",
     description="pulp-deb plugin for the Pulp Project",
     license="GPLv2+",
     author="Matthias Dellweg",

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "pulpcore>=3.4",
+    "pulpcore>=3.5,<3.6",
     "python-debian>=0.1.36",
 ]
 
 setup(
     name="pulp-deb",
-    version="2.5.0b1.dev",
+    version="2.5.0b1",
     description="pulp-deb plugin for the Pulp Project",
     license="GPLv2+",
     author="Matthias Dellweg",


### PR DESCRIPTION
[noissue]

* Removed .dev from the version
* Adjusted the pulpcore requirement
* Ran towncrier in the project root (no manual changes)
* Finally bumped to the next development version (`2.6.0b1.dev`) in a second commit.