### PR TITLE
Fix gnupg metadata verification

### DIFF
--- a/plugins/pulp_deb/plugins/importers/sync.py
+++ b/plugins/pulp_deb/plugins/importers/sync.py
@@ -184,7 +184,10 @@ class ParseReleaseStep(publish_step.PluginStep):
         # check signature
         if not self.get_config().get_boolean(constants.CONFIG_REQUIRE_SIGNATURE, False):
             return
-        gpg = self.gnupg_factory(homedir=os.path.join(self.get_working_dir(), 'gpg-home'))
+        worker_gpg_homedir = os.path.join(self.get_working_dir(), 'gpg-home')
+        if not os.path.exists(worker_gpg_homedir):
+            os.mkdir(worker_gpg_homedir, 0o700)
+        gpg = self.gnupg_factory(homedir=worker_gpg_homedir)
         shared_gpg = self.gnupg_factory(homedir=os.path.join('/', 'var', 'lib', 'pulp', 'gpg-home'))
 
         if self.get_config().get(constants.CONFIG_GPG_KEYS):

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -26,7 +26,7 @@ class TestModel(testbase.TestCase):
             'architecture': 'amd64',
             'checksum': '177937795c2ef5b381718aefe2981ada4e8cfe458226348d87a6f5b100a4612b',  # noqa
             'checksumtype': 'sha256',
-            })
+        })
 
     def test_from_file_different_checksumtype(self):
         metadata = dict(checksumtype='sha1',

--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -85,13 +85,13 @@ def create_dirs(opts):
 
 def getlinks():
     links = []
-    for l in LINKS:
-        if isinstance(l, (list, tuple)):
-            src = l[0]
-            dst = l[1]
+    for link in LINKS:
+        if isinstance(link, (list, tuple)):
+            src = link[0]
+            dst = link[1]
         else:
-            src = l
-            dst = os.path.join('/', l)
+            src = link
+            dst = os.path.join('/', link)
         links.append((src, dst))
     return links
 


### PR DESCRIPTION
It looks like a newer version of python2-gnupg now expects the gnupg
home folder to exist before any keys are imported (whereas the older
version presumably just created it if it was not there already).