### PR TITLE
Add a long_description to the python package

### DIFF
--- a/CHANGES/6882.misc
+++ b/CHANGES/6882.misc
@@ -1,0 +1,1 @@
+Added a long_description to the python package.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
 # pulp_deb
 
 ![build status](https://travis-ci.com/pulp/pulp_deb.svg?branch=master)
+![python versions](https://img.shields.io/pypi/pyversions/pulp_deb.svg)
 
 A Pulp plugin to host APT repositories.
 
-For more information, please visit the [Pulp project home page][1], or see the [plugin documentation][2].
-For released versions visit [pypi.org][3].
-If you want to report a bug, see the [issue tracker][4].
+Visit the [Pulp project homepage][1] or see the [plugin documentation][2] for more information.
+If you want to report a bug, see the [issue tracker][3].
+
+The most important places:
+
+* The [Pulp project homepage][1].
+* The [plugin documentation][2].
+* The [plugin issue tracker][3].
+* The [plugin source repository][4].
+* Released [python packages on pypi.org][5].
+* The [pulp-deb-client Python package][6] (contains API bindings for Python).
+* The [pulp-deb-client Ruby Gem][7] (contains API bindings for Ruby).
 
 [1]: https://pulpproject.org
 [2]: https://pulp-deb.readthedocs.io/en/latest/
-[3]: https://pypi.org/project/pulp-deb/
-[4]: https://pulp.plan.io/projects/pulp_deb/issues/
+[3]: https://pulp.plan.io/projects/pulp_deb/issues/
+[4]: https://github.com/pulp/pulp_deb
+[5]: https://pypi.org/project/pulp-deb/
+[6]: https://pypi.org/project/pulp-deb-client/
+[7]: https://rubygems.org/gems/pulp_deb_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pulpcore>=3.5
+python-debian>=0.1.36

--- a/setup.py
+++ b/setup.py
@@ -2,19 +2,22 @@
 
 from setuptools import find_packages, setup
 
-requirements = [
-    "pulpcore>=3.5",
-    "python-debian>=0.1.36",
-]
+with open("requirements.txt") as requirements:
+    requirements = requirements.readlines()
+
+with open("README.md") as description:
+    long_description = description.read()
 
 setup(
     name="pulp-deb",
     version="2.6.0b1.dev",
     description="pulp-deb plugin for the Pulp Project",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     license="GPLv2+",
     author="Matthias Dellweg",
     author_email="dellweg@atix.de",
-    url="https://pulpproject.org/#deb",
+    url="https://pulpproject.org",
     python_requires=">=3.6",
     install_requires=requirements,
     include_package_data=True,


### PR DESCRIPTION
fixes #6882
https://pulp.plan.io/issues/6882

The motivation was to provide a "project description" on pypi.org. This
necessitated another rework of the README.md file to make it usable for
arbitrary locations. There was some minor cleanup of setup.py as
informed by pulpcore and pulp_rpm.