### PR TITLE
Add meaningful REST API endpoint descriptions

### DIFF
--- a/CHANGES/7355.doc
+++ b/CHANGES/7355.doc
@@ -1,0 +1,1 @@
+Added meaningful endpoint descriptions to the REST API documentation.

--- a/docs/_static/api.json
+++ b/docs/_static/api.json
@@ -305,7 +305,7 @@
         "/pulp/api/v3/content/deb/generic_contents/": {
             "get": {
                 "operationId": "pulp_api_v3_content_deb_generic_contents_list",
-                "description": "A ViewSet for GenericContent.",
+                "description": "GenericContent is a catch all category for storing files not covered by any other type.\n\nAssociated artifacts: Exactly one arbitrary file that does not match any other type.\n\nThis is needed to store arbitrary files for use with the verbatim publisher. If you are not\nusing the verbatim publisher, you may ignore this type.",
                 "parameters": [
                     {
                         "name": "limit",
@@ -486,7 +486,7 @@
         "{generic_content_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for GenericContent.",
+                "description": "GenericContent is a catch all category for storing files not covered by any other type.\n\nAssociated artifacts: Exactly one arbitrary file that does not match any other type.\n\nThis is needed to store arbitrary files for use with the verbatim publisher. If you are not\nusing the verbatim publisher, you may ignore this type.",
                 "parameters": [
                     {
                         "in": "path",
@@ -541,7 +541,7 @@
         "/pulp/api/v3/content/deb/installer_file_indices/": {
             "get": {
                 "operationId": "pulp_api_v3_content_deb_installer_file_indices_list",
-                "description": "A ViewSet for InstallerFileIndex.",
+                "description": "An InstallerFileIndex represents the indices for a set of installer files.\n\nAssociated artifacts: Exactly one 'SHA256SUMS' and/or 'MD5SUMS' file.\n\nEach InstallerFileIndes is associated with a single component-architecture combination within\na single Release. Note that installer files are currently used exclusively for verbatim\npublications. The APT publisher (both simple and structured mode) does not make use of installer\ncontent.",
                 "parameters": [
                     {
                         "name": "architecture",
@@ -696,7 +696,7 @@
             },
             "post": {
                 "operationId": "pulp_api_v3_content_deb_installer_file_indices_create",
-                "description": "A ViewSet for InstallerFileIndex.",
+                "description": "An InstallerFileIndex represents the indices for a set of installer files.\n\nAssociated artifacts: Exactly one 'SHA256SUMS' and/or 'MD5SUMS' file.\n\nEach InstallerFileIndes is associated with a single component-architecture combination within\na single Release. Note that installer files are currently used exclusively for verbatim\npublications. The APT publisher (both simple and structured mode) does not make use of installer\ncontent.",
                 "tags": [
                     "Content: Installer_File_Indices"
                 ],
@@ -745,7 +745,7 @@
         "{installer_file_index_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for InstallerFileIndex.",
+                "description": "An InstallerFileIndex represents the indices for a set of installer files.\n\nAssociated artifacts: Exactly one 'SHA256SUMS' and/or 'MD5SUMS' file.\n\nEach InstallerFileIndes is associated with a single component-architecture combination within\na single Release. Note that installer files are currently used exclusively for verbatim\npublications. The APT publisher (both simple and structured mode) does not make use of installer\ncontent.",
                 "parameters": [
                     {
                         "in": "path",
@@ -800,7 +800,7 @@
         "/pulp/api/v3/content/deb/installer_packages/": {
             "get": {
                 "operationId": "pulp_api_v3_content_deb_installer_packages_list",
-                "description": "A ViewSet for InstallerPackage.",
+                "description": "An InstallerPackage represents a '.udeb' installer package.\n\nAssociated artifacts: Exactly one '.udeb' installer package file.\n\nNote that installer packages are currently used exclusively for verbatim publications. The APT\npublisher (both simple and structured mode) will not include these packages.",
                 "parameters": [
                     {
                         "name": "architecture",
@@ -1130,7 +1130,7 @@
         "{installer_package_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for InstallerPackage.",
+                "description": "An InstallerPackage represents a '.udeb' installer package.\n\nAssociated artifacts: Exactly one '.udeb' installer package file.\n\nNote that installer packages are currently used exclusively for verbatim publications. The APT\npublisher (both simple and structured mode) will not include these packages.",
                 "parameters": [
                     {
                         "in": "path",
@@ -1185,7 +1185,7 @@
         "/pulp/api/v3/content/deb/package_indices/": {
             "get": {
                 "operationId": "pulp_api_v3_content_deb_package_indices_list",
-                "description": "A ViewSet for PackageIndex.",
+                "description": "A PackageIndex represents the package indices of a single component-architecture combination.\n\nAssociated artifacts: Exactly one 'Packages' file. May optionally include one or more of\n'Packages.gz', 'Packages.xz', 'Release'. If included, the 'Release' file is a legacy\nper-component-and-architecture Release file.\n\nNote: The verbatim publisher will republish all associated artifacts, while the APT publisher\n(both simple and structured mode) will generate any 'Packages' files it needs when creating the\npublication. It does not make use of PackageIndex content.",
                 "parameters": [
                     {
                         "name": "architecture",
@@ -1340,7 +1340,7 @@
             },
             "post": {
                 "operationId": "pulp_api_v3_content_deb_package_indices_create",
-                "description": "A ViewSet for PackageIndex.",
+                "description": "A PackageIndex represents the package indices of a single component-architecture combination.\n\nAssociated artifacts: Exactly one 'Packages' file. May optionally include one or more of\n'Packages.gz', 'Packages.xz', 'Release'. If included, the 'Release' file is a legacy\nper-component-and-architecture Release file.\n\nNote: The verbatim publisher will republish all associated artifacts, while the APT publisher\n(both simple and structured mode) will generate any 'Packages' files it needs when creating the\npublication. It does not make use of PackageIndex content.",
                 "tags": [
                     "Content: Package_Indices"
                 ],
@@ -1389,7 +1389,7 @@
         "{package_index_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for PackageIndex.",
+                "description": "A PackageIndex represents the package indices of a single component-architecture combination.\n\nAssociated artifacts: Exactly one 'Packages' file. May optionally include one or more of\n'Packages.gz', 'Packages.xz', 'Release'. If included, the 'Release' file is a legacy\nper-component-and-architecture Release file.\n\nNote: The verbatim publisher will republish all associated artifacts, while the APT publisher\n(both simple and structured mode) will generate any 'Packages' files it needs when creating the\npublication. It does not make use of PackageIndex content.",
                 "parameters": [
                     {
                         "in": "path",
@@ -1444,7 +1444,7 @@
         "/pulp/api/v3/content/deb/package_release_components/": {
             "get": {
                 "operationId": "pulp_api_v3_content_deb_package_release_components_list",
-                "description": "A ViewSet for PackageReleaseComponent.",
+                "description": "A PackageReleaseComponent associates a Package with a ReleaseComponent.\n\nAssociated artifacts: None; contains only metadata.\n\nThis simply stores the information which packages are part of which components.",
                 "parameters": [
                     {
                         "name": "limit",
@@ -1581,7 +1581,7 @@
             },
             "post": {
                 "operationId": "pulp_api_v3_content_deb_package_release_components_create",
-                "description": "A ViewSet for PackageReleaseComponent.",
+                "description": "A PackageReleaseComponent associates a Package with a ReleaseComponent.\n\nAssociated artifacts: None; contains only metadata.\n\nThis simply stores the information which packages are part of which components.",
                 "tags": [
                     "Content: Package_Release_Components"
                 ],
@@ -1630,7 +1630,7 @@
         "{package_release_component_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for PackageReleaseComponent.",
+                "description": "A PackageReleaseComponent associates a Package with a ReleaseComponent.\n\nAssociated artifacts: None; contains only metadata.\n\nThis simply stores the information which packages are part of which components.",
                 "parameters": [
                     {
                         "in": "path",
@@ -1685,7 +1685,7 @@
         "/pulp/api/v3/content/deb/packages/": {
             "get": {
                 "operationId": "pulp_api_v3_content_deb_packages_list",
-                "description": "A ViewSet for Package.",
+                "description": "A Package represents a '.deb' binary package.\n\nAssociated artifacts: Exactly one '.deb' package file.",
                 "parameters": [
                     {
                         "name": "architecture",
@@ -2024,7 +2024,7 @@
         "{package_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for Package.",
+                "description": "A Package represents a '.deb' binary package.\n\nAssociated artifacts: Exactly one '.deb' package file.",
                 "parameters": [
                     {
                         "in": "path",
@@ -2079,7 +2079,7 @@
         "/pulp/api/v3/content/deb/release_architectures/": {
             "get": {
                 "operationId": "pulp_api_v3_content_deb_release_architectures_list",
-                "description": "A ViewSet for ReleaseArchitecture.",
+                "description": "A ReleaseArchitecture represents a single dpkg architecture string.\n\nAssociated artifacts: None; contains only metadata.\n\nEvery ReleaseArchitecture is always associated with exactly one Release. This indicates that\nthe release/distribution in question supports this architecture.",
                 "parameters": [
                     {
                         "name": "architecture",
@@ -2216,7 +2216,7 @@
             },
             "post": {
                 "operationId": "pulp_api_v3_content_deb_release_architectures_create",
-                "description": "A ViewSet for ReleaseArchitecture.",
+                "description": "A ReleaseArchitecture represents a single dpkg architecture string.\n\nAssociated artifacts: None; contains only metadata.\n\nEvery ReleaseArchitecture is always associated with exactly one Release. This indicates that\nthe release/distribution in question supports this architecture.",
                 "tags": [
                     "Content: Release_Architectures"
                 ],
@@ -2265,7 +2265,7 @@
         "{release_architecture_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for ReleaseArchitecture.",
+                "description": "A ReleaseArchitecture represents a single dpkg architecture string.\n\nAssociated artifacts: None; contains only metadata.\n\nEvery ReleaseArchitecture is always associated with exactly one Release. This indicates that\nthe release/distribution in question supports this architecture.",
                 "parameters": [
                     {
                         "in": "path",
@@ -2320,7 +2320,7 @@
         "/pulp/api/v3/content/deb/release_components/": {
             "get": {
                 "operationId": "pulp_api_v3_content_deb_release_components_list",
-                "description": "A ViewSet for ReleaseComponent.",
+                "description": "A ReleaseComponent represents a single APT repository component.\n\nAssociated artifacts: None; contains only metadata.\n\nEvery ReleaseComponent is always associated with exactly one Release. This indicates that the\nrelease/distribution in question contains this component.",
                 "parameters": [
                     {
                         "name": "component",
@@ -2457,7 +2457,7 @@
             },
             "post": {
                 "operationId": "pulp_api_v3_content_deb_release_components_create",
-                "description": "A ViewSet for ReleaseComponent.",
+                "description": "A ReleaseComponent represents a single APT repository component.\n\nAssociated artifacts: None; contains only metadata.\n\nEvery ReleaseComponent is always associated with exactly one Release. This indicates that the\nrelease/distribution in question contains this component.",
                 "tags": [
                     "Content: Release_Components"
                 ],
@@ -2506,7 +2506,7 @@
         "{release_component_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for ReleaseComponent.",
+                "description": "A ReleaseComponent represents a single APT repository component.\n\nAssociated artifacts: None; contains only metadata.\n\nEvery ReleaseComponent is always associated with exactly one Release. This indicates that the\nrelease/distribution in question contains this component.",
                 "parameters": [
                     {
                         "in": "path",
@@ -2561,7 +2561,7 @@
         "/pulp/api/v3/content/deb/release_files/": {
             "get": {
                 "operationId": "pulp_api_v3_content_deb_release_files_list",
-                "description": "A ViewSet for ReleaseFile.",
+                "description": "A ReleaseFile represents the Release file(s) from a single APT distribution.\n\nAssociated artifacts: At least one of 'Release' and 'InRelease' file. If the 'Release' file is\npresent, then there may also be a 'Release.gpg' detached signature file for it.\n\nNote: The verbatim publisher will republish all associated artifacts, while the APT publisher\n(both simple and structured mode) will generate any 'Release' files it needs when creating the\npublication. It does not make use of ReleaseFile content.",
                 "parameters": [
                     {
                         "name": "codename",
@@ -2716,7 +2716,7 @@
             },
             "post": {
                 "operationId": "pulp_api_v3_content_deb_release_files_create",
-                "description": "A ViewSet for ReleaseFile.",
+                "description": "A ReleaseFile represents the Release file(s) from a single APT distribution.\n\nAssociated artifacts: At least one of 'Release' and 'InRelease' file. If the 'Release' file is\npresent, then there may also be a 'Release.gpg' detached signature file for it.\n\nNote: The verbatim publisher will republish all associated artifacts, while the APT publisher\n(both simple and structured mode) will generate any 'Release' files it needs when creating the\npublication. It does not make use of ReleaseFile content.",
                 "tags": [
                     "Content: Release_Files"
                 ],
@@ -2765,7 +2765,7 @@
         "{release_file_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for ReleaseFile.",
+                "description": "A ReleaseFile represents the Release file(s) from a single APT distribution.\n\nAssociated artifacts: At least one of 'Release' and 'InRelease' file. If the 'Release' file is\npresent, then there may also be a 'Release.gpg' detached signature file for it.\n\nNote: The verbatim publisher will republish all associated artifacts, while the APT publisher\n(both simple and structured mode) will generate any 'Release' files it needs when creating the\npublication. It does not make use of ReleaseFile content.",
                 "parameters": [
                     {
                         "in": "path",
@@ -2820,7 +2820,7 @@
         "/pulp/api/v3/content/deb/releases/": {
             "get": {
                 "operationId": "pulp_api_v3_content_deb_releases_list",
-                "description": "A ViewSet for Release.",
+                "description": "A Release represents a single APT release/distribution.\n\nAssociated artifacts: None; contains only metadata.\n\nNote that in the context of the \"Release content\", the terms \"distribution\" and \"release\"\nare synonyms. An \"APT repository release/distribution\" is associated with a single 'Release'\nfile below the 'dists/' folder. The \"distribution\" refers to the path between 'dists/' and the\n'Release' file. The \"distribution\" could be considered the name of the \"release\". It is often\n(but not always) equal to the \"codename\" or \"suite\".",
                 "parameters": [
                     {
                         "name": "codename",
@@ -2966,7 +2966,7 @@
             },
             "post": {
                 "operationId": "pulp_api_v3_content_deb_releases_create",
-                "description": "A ViewSet for Release.",
+                "description": "A Release represents a single APT release/distribution.\n\nAssociated artifacts: None; contains only metadata.\n\nNote that in the context of the \"Release content\", the terms \"distribution\" and \"release\"\nare synonyms. An \"APT repository release/distribution\" is associated with a single 'Release'\nfile below the 'dists/' folder. The \"distribution\" refers to the path between 'dists/' and the\n'Release' file. The \"distribution\" could be considered the name of the \"release\". It is often\n(but not always) equal to the \"codename\" or \"suite\".",
                 "tags": [
                     "Content: Releases"
                 ],
@@ -3015,7 +3015,7 @@
         "{release_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for Release.",
+                "description": "A Release represents a single APT release/distribution.\n\nAssociated artifacts: None; contains only metadata.\n\nNote that in the context of the \"Release content\", the terms \"distribution\" and \"release\"\nare synonyms. An \"APT repository release/distribution\" is associated with a single 'Release'\nfile below the 'dists/' folder. The \"distribution\" refers to the path between 'dists/' and the\n'Release' file. The \"distribution\" could be considered the name of the \"release\". It is often\n(but not always) equal to the \"codename\" or \"suite\".",
                 "parameters": [
                     {
                         "in": "path",
@@ -3070,7 +3070,7 @@
         "/pulp/api/v3/distributions/deb/apt/": {
             "get": {
                 "operationId": "pulp_api_v3_distributions_deb_apt_list",
-                "description": "ViewSet for AptDistributions.",
+                "description": "An AptDistribution is just an AptPublication made available via the content app.\n\nCreating an AptDistribution is a comparatively quick action. This way Pulp users may take as\nmuch time as is needed to prepare a VerbatimPublication or AptPublication, and then control the\nexact moment when that publication is made available.",
                 "parameters": [
                     {
                         "name": "base_path",
@@ -3265,7 +3265,7 @@
         "{apt_distribution_href}": {
             "get": {
                 "operationId": "read",
-                "description": "ViewSet for AptDistributions.",
+                "description": "An AptDistribution is just an AptPublication made available via the content app.\n\nCreating an AptDistribution is a comparatively quick action. This way Pulp users may take as\nmuch time as is needed to prepare a VerbatimPublication or AptPublication, and then control the\nexact moment when that publication is made available.",
                 "parameters": [
                     {
                         "in": "path",
@@ -4864,7 +4864,7 @@
         "/pulp/api/v3/publications/deb/apt/": {
             "get": {
                 "operationId": "pulp_api_v3_publications_deb_apt_list",
-                "description": "A ViewSet for AptPublication.",
+                "description": "An AptPublication is the ready to serve Pulp-internal representation of an AptRepositoryVersion.\n\nWhen creating an APT publication, users must use simple or structured mode (or both). If the\npublication should include '.deb' packages that were manually uploaded to the relevant\nAptRepository, users must use 'simple=true'. Conversely, 'structured=true' is only useful for\npublishing content obtained via synchronization. Once a Pulp publication has been created, it\ncan be served by creating a Pulp distribution (in a near atomic action).",
                 "parameters": [
                     {
                         "name": "limit",
@@ -5068,7 +5068,7 @@
         "{apt_publication_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for AptPublication.",
+                "description": "An AptPublication is the ready to serve Pulp-internal representation of an AptRepositoryVersion.\n\nWhen creating an APT publication, users must use simple or structured mode (or both). If the\npublication should include '.deb' packages that were manually uploaded to the relevant\nAptRepository, users must use 'simple=true'. Conversely, 'structured=true' is only useful for\npublishing content obtained via synchronization. Once a Pulp publication has been created, it\ncan be served by creating a Pulp distribution (in a near atomic action).",
                 "parameters": [
                     {
                         "in": "path",
@@ -5121,7 +5121,7 @@
             },
             "delete": {
                 "operationId": "delete",
-                "description": "A ViewSet for AptPublication.",
+                "description": "An AptPublication is the ready to serve Pulp-internal representation of an AptRepositoryVersion.\n\nWhen creating an APT publication, users must use simple or structured mode (or both). If the\npublication should include '.deb' packages that were manually uploaded to the relevant\nAptRepository, users must use 'simple=true'. Conversely, 'structured=true' is only useful for\npublishing content obtained via synchronization. Once a Pulp publication has been created, it\ncan be served by creating a Pulp distribution (in a near atomic action).",
                 "parameters": [
                     {
                         "in": "path",
@@ -5153,7 +5153,7 @@
         "/pulp/api/v3/publications/deb/verbatim/": {
             "get": {
                 "operationId": "pulp_api_v3_publications_deb_verbatim_list",
-                "description": "A ViewSet for VerbatimPublication.",
+                "description": "An VerbatimPublication is the Pulp-internal representation of a \"mirrored\" AptRepositoryVersion.\n\nIn other words, the verbatim publisher will recreate the synced subset of some a APT\nrepository using the exact same metadata files and signatures as used by the upstream original.\nOnce a Pulp publication has been created, it can be served by creating a Pulp distribution (in\na near atomic action).",
                 "parameters": [
                     {
                         "name": "limit",
@@ -5357,7 +5357,7 @@
         "{verbatim_publication_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for VerbatimPublication.",
+                "description": "An VerbatimPublication is the Pulp-internal representation of a \"mirrored\" AptRepositoryVersion.\n\nIn other words, the verbatim publisher will recreate the synced subset of some a APT\nrepository using the exact same metadata files and signatures as used by the upstream original.\nOnce a Pulp publication has been created, it can be served by creating a Pulp distribution (in\na near atomic action).",
                 "parameters": [
                     {
                         "in": "path",
@@ -5410,7 +5410,7 @@
             },
             "delete": {
                 "operationId": "delete",
-                "description": "A ViewSet for VerbatimPublication.",
+                "description": "An VerbatimPublication is the Pulp-internal representation of a \"mirrored\" AptRepositoryVersion.\n\nIn other words, the verbatim publisher will recreate the synced subset of some a APT\nrepository using the exact same metadata files and signatures as used by the upstream original.\nOnce a Pulp publication has been created, it can be served by creating a Pulp distribution (in\na near atomic action).",
                 "parameters": [
                     {
                         "in": "path",
@@ -5442,7 +5442,7 @@
         "/pulp/api/v3/remotes/deb/apt/": {
             "get": {
                 "operationId": "pulp_api_v3_remotes_deb_apt_list",
-                "description": "A ViewSet for AptRemote.",
+                "description": "An AptRemote represents an external APT repository content source.\n\nIt contains the location of the upstream APT repository, as well as the user options that are\napplied when using the remote to synchronize the upstream repository to Pulp.",
                 "parameters": [
                     {
                         "name": "limit",
@@ -5606,7 +5606,7 @@
             },
             "post": {
                 "operationId": "pulp_api_v3_remotes_deb_apt_create",
-                "description": "A ViewSet for AptRemote.",
+                "description": "An AptRemote represents an external APT repository content source.\n\nIt contains the location of the upstream APT repository, as well as the user options that are\napplied when using the remote to synchronize the upstream repository to Pulp.",
                 "tags": [
                     "Remotes: Apt"
                 ],
@@ -5655,7 +5655,7 @@
         "{apt_remote_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for AptRemote.",
+                "description": "An AptRemote represents an external APT repository content source.\n\nIt contains the location of the upstream APT repository, as well as the user options that are\napplied when using the remote to synchronize the upstream repository to Pulp.",
                 "parameters": [
                     {
                         "in": "path",
@@ -6104,7 +6104,7 @@
         "/pulp/api/v3/repositories/deb/apt/": {
             "get": {
                 "operationId": "pulp_api_v3_repositories_deb_apt_list",
-                "description": "A ViewSet for AptRepository.",
+                "description": "An AptRepository is the locally stored, Pulp-internal representation of a APT repository.\n\nIt may be filled with content via synchronization or content upload to create an\nAptRepositoryVersion.",
                 "parameters": [
                     {
                         "name": "limit",
@@ -6214,7 +6214,7 @@
             },
             "post": {
                 "operationId": "pulp_api_v3_repositories_deb_apt_create",
-                "description": "A ViewSet for AptRepository.",
+                "description": "An AptRepository is the locally stored, Pulp-internal representation of a APT repository.\n\nIt may be filled with content via synchronization or content upload to create an\nAptRepositoryVersion.",
                 "tags": [
                     "Repositories: Apt"
                 ],
@@ -6263,7 +6263,7 @@
         "{apt_repository_href}": {
             "get": {
                 "operationId": "read",
-                "description": "A ViewSet for AptRepository.",
+                "description": "An AptRepository is the locally stored, Pulp-internal representation of a APT repository.\n\nIt may be filled with content via synchronization or content upload to create an\nAptRepositoryVersion.",
                 "parameters": [
                     {
                         "in": "path",
@@ -6670,7 +6670,7 @@
         "{apt_repository_version_href}versions/": {
             "get": {
                 "operationId": "list",
-                "description": "AptRepositoryVersion represents a single deb repository version.",
+                "description": "An AptRepositoryVersion represents a single APT repository version as stored by Pulp.\n\nIt may be used as the basis for the creation of Pulp distributions in order to actually serve\nthe content contained within the repository version.",
                 "parameters": [
                     {
                         "in": "path",
@@ -6898,7 +6898,7 @@
         "{apt_repository_version_href}": {
             "get": {
                 "operationId": "read",
-                "description": "AptRepositoryVersion represents a single deb repository version.",
+                "description": "An AptRepositoryVersion represents a single APT repository version as stored by Pulp.\n\nIt may be used as the basis for the creation of Pulp distributions in order to actually serve\nthe content contained within the repository version.",
                 "parameters": [
                     {
                         "in": "path",

--- a/pulp_deb/app/viewsets/content.py
+++ b/pulp_deb/app/viewsets/content.py
@@ -20,8 +20,14 @@ class GenericContentFilter(ContentFilter):
 
 
 class GenericContentViewSet(SingleArtifactContentUploadViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for GenericContent.
+    GenericContent is a catch all category for storing files not covered by any other type.
+
+    Associated artifacts: Exactly one arbitrary file that does not match any other type.
+
+    This is needed to store arbitrary files for use with the verbatim publisher. If you are not
+    using the verbatim publisher, you may ignore this type.
     """
 
     endpoint_name = "generic_contents"
@@ -60,8 +66,11 @@ class PackageFilter(ContentFilter):
 
 
 class PackageViewSet(SingleArtifactContentUploadViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for Package.
+    A Package represents a '.deb' binary package.
+
+    Associated artifacts: Exactly one '.deb' package file.
     """
 
     endpoint_name = "packages"
@@ -99,8 +108,14 @@ class InstallerPackageFilter(ContentFilter):
 
 
 class InstallerPackageViewSet(SingleArtifactContentUploadViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for InstallerPackage.
+    An InstallerPackage represents a '.udeb' installer package.
+
+    Associated artifacts: Exactly one '.udeb' installer package file.
+
+    Note that installer packages are currently used exclusively for verbatim publications. The APT
+    publisher (both simple and structured mode) will not include these packages.
     """
 
     endpoint_name = "installer_packages"
@@ -123,8 +138,16 @@ class ReleaseFileFilter(ContentFilter):
 
 
 class ReleaseFileViewSet(ContentViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for ReleaseFile.
+    A ReleaseFile represents the Release file(s) from a single APT distribution.
+
+    Associated artifacts: At least one of 'Release' and 'InRelease' file. If the 'Release' file is
+    present, then there may also be a 'Release.gpg' detached signature file for it.
+
+    Note: The verbatim publisher will republish all associated artifacts, while the APT publisher
+    (both simple and structured mode) will generate any 'Release' files it needs when creating the
+    publication. It does not make use of ReleaseFile content.
     """
 
     endpoint_name = "release_files"
@@ -144,8 +167,17 @@ class PackageIndexFilter(ContentFilter):
 
 
 class PackageIndexViewSet(ContentViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for PackageIndex.
+    A PackageIndex represents the package indices of a single component-architecture combination.
+
+    Associated artifacts: Exactly one 'Packages' file. May optionally include one or more of
+    'Packages.gz', 'Packages.xz', 'Release'. If included, the 'Release' file is a legacy
+    per-component-and-architecture Release file.
+
+    Note: The verbatim publisher will republish all associated artifacts, while the APT publisher
+    (both simple and structured mode) will generate any 'Packages' files it needs when creating the
+    publication. It does not make use of PackageIndex content.
     """
 
     endpoint_name = "package_indices"
@@ -165,8 +197,16 @@ class InstallerFileIndexFilter(ContentFilter):
 
 
 class InstallerFileIndexViewSet(ContentViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for InstallerFileIndex.
+    An InstallerFileIndex represents the indices for a set of installer files.
+
+    Associated artifacts: Exactly one 'SHA256SUMS' and/or 'MD5SUMS' file.
+
+    Each InstallerFileIndes is associated with a single component-architecture combination within
+    a single Release. Note that installer files are currently used exclusively for verbatim
+    publications. The APT publisher (both simple and structured mode) does not make use of installer
+    content.
     """
 
     endpoint_name = "installer_file_indices"
@@ -186,8 +226,17 @@ class ReleaseFilter(ContentFilter):
 
 
 class ReleaseViewSet(ContentViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for Release.
+    A Release represents a single APT release/distribution.
+
+    Associated artifacts: None; contains only metadata.
+
+    Note that in the context of the "Release content", the terms "distribution" and "release"
+    are synonyms. An "APT repository release/distribution" is associated with a single 'Release'
+    file below the 'dists/' folder. The "distribution" refers to the path between 'dists/' and the
+    'Release' file. The "distribution" could be considered the name of the "release". It is often
+    (but not always) equal to the "codename" or "suite".
     """
 
     endpoint_name = "releases"
@@ -207,8 +256,14 @@ class ReleaseArchitectureFilter(ContentFilter):
 
 
 class ReleaseArchitectureViewSet(ContentViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for ReleaseArchitecture.
+    A ReleaseArchitecture represents a single dpkg architecture string.
+
+    Associated artifacts: None; contains only metadata.
+
+    Every ReleaseArchitecture is always associated with exactly one Release. This indicates that
+    the release/distribution in question supports this architecture.
     """
 
     endpoint_name = "release_architectures"
@@ -228,8 +283,14 @@ class ReleaseComponentFilter(ContentFilter):
 
 
 class ReleaseComponentViewSet(ContentViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for ReleaseComponent.
+    A ReleaseComponent represents a single APT repository component.
+
+    Associated artifacts: None; contains only metadata.
+
+    Every ReleaseComponent is always associated with exactly one Release. This indicates that the
+    release/distribution in question contains this component.
     """
 
     endpoint_name = "release_components"
@@ -249,8 +310,13 @@ class PackageReleaseComponentFilter(ContentFilter):
 
 
 class PackageReleaseComponentViewSet(ContentViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for PackageReleaseComponent.
+    A PackageReleaseComponent associates a Package with a ReleaseComponent.
+
+    Associated artifacts: None; contains only metadata.
+
+    This simply stores the information which packages are part of which components.
     """
 
     endpoint_name = "package_release_components"

--- a/pulp_deb/app/viewsets/publication.py
+++ b/pulp_deb/app/viewsets/publication.py
@@ -14,8 +14,14 @@ from pulp_deb.app import models, serializers, tasks
 
 
 class VerbatimPublicationViewSet(PublicationViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for VerbatimPublication.
+    An VerbatimPublication is the Pulp-internal representation of a "mirrored" AptRepositoryVersion.
+
+    In other words, the verbatim publisher will recreate the synced subset of some a APT
+    repository using the exact same metadata files and signatures as used by the upstream original.
+    Once a Pulp publication has been created, it can be served by creating a Pulp distribution (in
+    a near atomic action).
     """
 
     endpoint_name = "verbatim"
@@ -46,8 +52,15 @@ class VerbatimPublicationViewSet(PublicationViewSet):
 
 
 class AptPublicationViewSet(PublicationViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for AptPublication.
+    An AptPublication is the ready to serve Pulp-internal representation of an AptRepositoryVersion.
+
+    When creating an APT publication, users must use simple or structured mode (or both). If the
+    publication should include '.deb' packages that were manually uploaded to the relevant
+    AptRepository, users must use 'simple=true'. Conversely, 'structured=true' is only useful for
+    publishing content obtained via synchronization. Once a Pulp publication has been created, it
+    can be served by creating a Pulp distribution (in a near atomic action).
     """
 
     endpoint_name = "apt"
@@ -86,8 +99,13 @@ class AptPublicationViewSet(PublicationViewSet):
 
 
 class AptDistributionViewSet(BaseDistributionViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    ViewSet for AptDistributions.
+    An AptDistribution is just an AptPublication made available via the content app.
+
+    Creating an AptDistribution is a comparatively quick action. This way Pulp users may take as
+    much time as is needed to prepare a VerbatimPublication or AptPublication, and then control the
+    exact moment when that publication is made available.
     """
 
     endpoint_name = "apt"

--- a/pulp_deb/app/viewsets/remote.py
+++ b/pulp_deb/app/viewsets/remote.py
@@ -6,8 +6,12 @@ from pulp_deb.app import models, serializers
 
 
 class AptRemoteViewSet(RemoteViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for AptRemote.
+    An AptRemote represents an external APT repository content source.
+
+    It contains the location of the upstream APT repository, as well as the user options that are
+    applied when using the remote to synchronize the upstream repository to Pulp.
     """
 
     endpoint_name = "apt"

--- a/pulp_deb/app/viewsets/repository.py
+++ b/pulp_deb/app/viewsets/repository.py
@@ -19,8 +19,12 @@ from pulp_deb.app import models, serializers, tasks
 
 
 class AptRepositoryViewSet(RepositoryViewSet, ModifyRepositoryActionMixin):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    A ViewSet for AptRepository.
+    An AptRepository is the locally stored, Pulp-internal representation of a APT repository.
+
+    It may be filled with content via synchronization or content upload to create an
+    AptRepositoryVersion.
     """
 
     endpoint_name = "apt"
@@ -56,8 +60,12 @@ class AptRepositoryViewSet(RepositoryViewSet, ModifyRepositoryActionMixin):
 
 
 class AptRepositoryVersionViewSet(RepositoryVersionViewSet):
+    # The doc string is a top level element of the user facing REST API documentation:
     """
-    AptRepositoryVersion represents a single deb repository version.
+    An AptRepositoryVersion represents a single APT repository version as stored by Pulp.
+
+    It may be used as the basis for the creation of Pulp distributions in order to actually serve
+    the content contained within the repository version.
     """
 
     parent_viewset = AptRepositoryViewSet


### PR DESCRIPTION
fixes #7355
https://pulp.plan.io/issues/7355

Motivated by https://github.com/pulp/pulp_deb/pull/198

The existing REST API docs (for reference): https://pulp-deb.readthedocs.io/en/latest/restapi.html