### PR TITLE
Release 2.6.0b1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.0b1
+current_version = 2.7.0b0.dev
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(0b)?(?P<patch>\d+)(\.(?P<release>[a-z]+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.0b1.dev
+current_version = 2.6.0b1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(0b)?(?P<patch>\d+)(\.(?P<release>[a-z]+))?

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,64 @@ Changelog
 
 .. towncrier release notes start
 
+2.6.0b1 (2020-09-01)
+====================
+
+Features
+--------
+
+- Added handling of packages with the same name, version, and architecture, when saving a new repository version.
+  `#6429 <https://pulp.plan.io/issues/6429>`_
+- Both simple and structured publish now use separate ``Architecture: all`` package indecies only.
+  `#6991 <https://pulp.plan.io/issues/6991>`_
+
+
+Bugfixes
+--------
+
+- Optional version strings are now stripped from the sourcename before using it for package file paths.
+  `#7153 <https://pulp.plan.io/issues/7153>`_
+- Fixed several field names in the to deb822 translation dict.
+  `#7190 <https://pulp.plan.io/issues/7190>`_
+- ``Section`` and ``Priority`` are no longer required for package indecies.
+  `#7236 <https://pulp.plan.io/issues/7236>`_
+- Fixed content creation for fields containing more than 255 characters by using ``TextField`` instead of ``CharField`` for all package model fields.
+  `#7257 <https://pulp.plan.io/issues/7257>`_
+- Fixed a bug where component path prefixes were added to package index paths twice instead of once when using structured publish.
+  `#7295 <https://pulp.plan.io/issues/7295>`_
+
+
+Improved Documentation
+----------------------
+
+- Added a note on per repository package uniqueness constraints to the feature overview documentation.
+  `#6429 <https://pulp.plan.io/issues/6429>`_
+- Fixed several URLs pointing at various API documentation.
+  `#6506 <https://pulp.plan.io/issues/6506>`_
+- Reworked the workflow documentation and added flow charts.
+  `#7148 <https://pulp.plan.io/issues/7148>`_
+- Completely refactored the documentation source files.
+  `#7211 <https://pulp.plan.io/issues/7211>`_
+- Added a high level "feature overview" documentation.
+  `#7318 <https://pulp.plan.io/issues/7318>`_
+- Added meaningful endpoint descriptions to the REST API documentation.
+  `#7355 <https://pulp.plan.io/issues/7355>`_
+
+
+Misc
+----
+
+- Added tests for repos with distribution paths that are not equal to the codename.
+  `#6051 <https://pulp.plan.io/issues/6051>`_
+- Added a long_description to the python package.
+  `#6882 <https://pulp.plan.io/issues/6882>`_
+- Added test to publish repository with package index files but no packages.
+  `#7344 <https://pulp.plan.io/issues/7344>`_
+
+
+----
+
+
 2.5.0b1 (2020-07-15)
 ====================
 

--- a/CHANGES/6051.misc
+++ b/CHANGES/6051.misc
@@ -1,1 +1,0 @@
-Added tests for repos with distribution paths that are not equal to the codename.

--- a/CHANGES/6429.doc
+++ b/CHANGES/6429.doc
@@ -1,1 +1,0 @@
-Added a note on per repository package uniqueness constraints to the feature overview documentation.

--- a/CHANGES/6429.feature
+++ b/CHANGES/6429.feature
@@ -1,1 +1,0 @@
-Added handling of packages with the same name, version, and architecture, when saving a new repository version.

--- a/CHANGES/6506.doc
+++ b/CHANGES/6506.doc
@@ -1,1 +1,0 @@
-Fixed several URLs pointing at various API documentation.

--- a/CHANGES/6882.misc
+++ b/CHANGES/6882.misc
@@ -1,1 +1,0 @@
-Added a long_description to the python package.

--- a/CHANGES/6991.bugfix
+++ b/CHANGES/6991.bugfix
@@ -1,1 +1,0 @@
-Fixed architecture=all package file location to be consistent for both modes simple and structured.

--- a/CHANGES/7148.doc
+++ b/CHANGES/7148.doc
@@ -1,1 +1,0 @@
-Reworked the workflow documentation and added flow charts.

--- a/CHANGES/7153.bugfix
+++ b/CHANGES/7153.bugfix
@@ -1,1 +1,0 @@
-Optional version strings are now stripped from the sourcename before using it for package file paths.

--- a/CHANGES/7190.bugfix
+++ b/CHANGES/7190.bugfix
@@ -1,1 +1,0 @@
-Fixed several field names in the to deb822 translation dict.

--- a/CHANGES/7211.doc
+++ b/CHANGES/7211.doc
@@ -1,1 +1,0 @@
-Completely refactored the documentation source files.

--- a/CHANGES/7236.bugfix
+++ b/CHANGES/7236.bugfix
@@ -1,1 +1,0 @@
-Fixed the bug which raised error that `section` and `priority` are required fields in package file.

--- a/CHANGES/7257.bugfix
+++ b/CHANGES/7257.bugfix
@@ -1,1 +1,0 @@
-Fixed content creation for fields containing more than 255 characters by using ``TextField`` instead of ``CharField`` for all package model fields.

--- a/CHANGES/7295.bugfix
+++ b/CHANGES/7295.bugfix
@@ -1,1 +1,0 @@
-Fixed a bug where component path prefixes were added to package index paths twice instead of once when using structured publish.

--- a/CHANGES/7318.doc
+++ b/CHANGES/7318.doc
@@ -1,1 +1,0 @@
-Added a high level "feature overview" documentation.

--- a/CHANGES/7344.misc
+++ b/CHANGES/7344.misc
@@ -1,1 +1,0 @@
-Added test to publish repository with package index files but no packages.

--- a/CHANGES/7355.doc
+++ b/CHANGES/7355.doc
@@ -1,1 +1,0 @@
-Added meaningful endpoint descriptions to the REST API documentation.

--- a/pulp_deb/__init__.py
+++ b/pulp_deb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.6.0b1"
+__version__ = "2.7.0b0.dev"
 
 default_app_config = "pulp_deb.app.PulpDebPluginAppConfig"

--- a/pulp_deb/__init__.py
+++ b/pulp_deb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.6.0b1.dev"
+__version__ = "2.6.0b1"
 
 default_app_config = "pulp_deb.app.PulpDebPluginAppConfig"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pulpcore>=3.6,<3.7
+pulpcore>=3.6
 python-debian>=0.1.36

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pulpcore>=3.5
+pulpcore>=3.6,<3.7
 python-debian>=0.1.36

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md") as description:
 
 setup(
     name="pulp-deb",
-    version="2.6.0b1",
+    version="2.7.0b0.dev",
     description="pulp-deb plugin for the Pulp Project",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md") as description:
 
 setup(
     name="pulp-deb",
-    version="2.6.0b1.dev",
+    version="2.6.0b1",
     description="pulp-deb plugin for the Pulp Project",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Generated using `python .travis/release.py minor --lower 3.6 --upper 3.7` plus some manual edits to the change log.