### PR TITLE
Building changelog for 2.6.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,19 @@ Changelog
 
 .. towncrier release notes start
 
+2.6.1 (2020-09-03)
+==================
+
+Misc
+----
+
+- Dropped the beta status of the plugin. The plugin is now GA!
+  `#6999 <https://pulp.plan.io/issues/6999>`_
+
+
+----
+
+
 2.6.0b1 (2020-09-01)
 ====================
 

--- a/CHANGES/6999.misc
+++ b/CHANGES/6999.misc
@@ -1,1 +1,0 @@
-Dropped the beta status of the plugin. The plugin is now GA!


### PR DESCRIPTION
[noissue]

(cherry picked from commit d4af74463ed09d95e3ec440cd4da5362b0601d7e)

This adds the changelog from https://github.com/pulp/pulp_deb/pull/212 to master.