### PR TITLE
Add compatibility release changelog entry

### DIFF
--- a/CHANGES/7566.misc
+++ b/CHANGES/7566.misc
@@ -1,0 +1,1 @@
+The plugin was defined as compatible with all pulpcore 3.7.* and 3.8.* releases.


### PR DESCRIPTION
fixes #7566
https://pulp.plan.io/issues/7566

So, I do not think `python .travis/release.py minor --lower 3.7 --upper 3.9` will work without any issues in the milestone/changelog entries in the repo.

This is the workaround I have come up with which has the added benefit of providing a meaningful changelog entry for the porposed `pulp_deb` `2.7.0` compatibility release.

If anyone has a better suggestion how to release a version of the plugin that is compatible with pulpcore `2.7.*`, I am all ears.