### PR TITLE
Fix milestone_id issue

### DIFF
--- a/.travis/release.py
+++ b/.travis/release.py
@@ -27,6 +27,7 @@ def validate_redmine_data(redmine_query_url, redmine_issues):
     project_set = set()
     stats = defaultdict(list)
     milestone_url = "\n[noissue]"
+    milestone_id = None
     for issue in redmine_issues:
         redmine_issue = redmine.issue.get(int(issue))
 
@@ -37,7 +38,7 @@ def validate_redmine_data(redmine_query_url, redmine_issues):
         status = redmine_issue.status.name
         if "CLOSE" not in status and status != "MODIFIED":
             stats["status_not_modified"].append(issue)
-        milestone_id = None
+
         try:
             milestone = redmine_issue.fixed_version.name
             milestone_id = redmine_issue.fixed_version.id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = 'setuptools.build_meta'
 
 [tool.towncrier]
-package = "pulp-deb"
+package = "pulp_deb"
 filename = "CHANGES.rst"
 directory = "CHANGES/"
 title_format = "{version} ({project_date})"


### PR DESCRIPTION
This fixes the milestone_id issue,
but now I'm facing some weird  `towncrier` issue:
```
pulp_deb on  milestone_id via 🐍 v3.8.0 (venv) took 4s 
❯ towncrier --version 2.7.0  
Loading template...
Finding news fragments...
Rendering news fragments...
Tried to import pulp-deb, but ran into this error: No module named 'pulp-deb'
Traceback (most recent call last):
  File "/home/faguiar/.pyenv/versions/venv/bin/towncrier", line 8, in <module>
    sys.exit(_main())
  File "/home/faguiar/.pyenv/versions/3.8.0/envs/venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/faguiar/.pyenv/versions/3.8.0/envs/venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/faguiar/.pyenv/versions/3.8.0/envs/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/faguiar/.pyenv/versions/3.8.0/envs/venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/faguiar/.pyenv/versions/3.8.0/envs/venv/lib/python3.8/site-packages/towncrier/__init__.py", line 53, in _main
    return __main(
  File "/home/faguiar/.pyenv/versions/3.8.0/envs/venv/lib/python3.8/site-packages/towncrier/__init__.py", line 112, in __main
    project_name = get_project_name(
  File "/home/faguiar/.pyenv/versions/3.8.0/envs/venv/lib/python3.8/site-packages/towncrier/_project.py", line 72, in get_project_name
    module = _get_package(package_dir, package)
  File "/home/faguiar/.pyenv/versions/3.8.0/envs/venv/lib/python3.8/site-packages/towncrier/_project.py", line 38, in _get_package
    raise Exception("Can't find your project :(")
Exception: Can't find your project :(
```