### PR TITLE
Enable test_s3 in the template config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   matrix:
     - TEST=pulp
     - TEST=docs
+    - TEST=s3
 services:
   - docker
 addons:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -91,5 +91,20 @@ if [[ "$TEST" == "pulp" || "$TEST" == "performance" || "$TEST" == "s3" ]]; then
     env: {BASE_URL: "http://pulp-fixtures"}' vars/main.yaml
 fi
 
+if [ "$TEST" = "s3" ]; then
+  export MINIO_ACCESS_KEY=AKIAIT2Z5TDYPX3ARJBA
+  export MINIO_SECRET_KEY=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
+  sed -i -e '/^services:/a \
+  - name: minio\
+    image: minio/minio\
+    env:\
+      MINIO_ACCESS_KEY: "'$MINIO_ACCESS_KEY'"\
+      MINIO_SECRET_KEY: "'$MINIO_SECRET_KEY'"\
+    command: "server /data"' vars/main.yaml
+  sed -i -e '$a s3_test: true\
+minio_access_key: "'$MINIO_ACCESS_KEY'"\
+minio_secret_key: "'$MINIO_SECRET_KEY'"' vars/main.yaml
+fi
+
 ansible-playbook build_container.yaml
 ansible-playbook start_container.yaml

--- a/.travis/post_before_script.sh
+++ b/.travis/post_before_script.sh
@@ -1,6 +1,6 @@
 set -euv
 
-if [ "$TEST" = "pulp" ] || [ "$TEST" = "performance" ]
+if [ "$TEST" = "pulp" ] || [ "$TEST" = "performance" ] || [ "$TEST" = "s3" ]
 then
   # Add signing service script and setup script:
   cat pulp_deb/tests/functional/sign_deb_release.sh | cmd_stdin_prefix bash -c "cat > /root/sign_deb_release.sh"

--- a/template_config.yml
+++ b/template_config.yml
@@ -33,7 +33,7 @@ redmine_project: pulp_deb
 stable_branch: null
 test_bindings: false
 test_performance: false
-test_s3: false
+test_s3: true
 travis_addtl_services: []
 travis_notifications: None
 update_redmine: true


### PR DESCRIPTION
[noissue]

I am still unsure what exactly the benefit is/if this is needed for `pulp_deb`, but I thought it does not hurt to test it out.