### PR TITLE
Remove ``test_file_descriptors``

### DIFF
--- a/pulp_deb/tests/functional/api/test_sync.py
+++ b/pulp_deb/tests/functional/api/test_sync.py
@@ -2,8 +2,8 @@
 """Tests that sync deb plugin repositories."""
 import unittest
 
-from pulp_smash import cli, config
-from pulp_smash.pulp3.constants import MEDIA_PATH
+from pulp_smash import config
+
 from pulp_smash.pulp3.utils import (
     gen_repo,
     get_added_content_summary,
@@ -101,43 +101,6 @@ class BasicSyncTestCase(unittest.TestCase):
 
         self.assertEqual(latest_version_href, repo.latest_version_href)
         self.assertDictEqual(get_content_summary(repo.to_dict()), fixture_summary)
-
-    def test_file_decriptors(self):
-        """Test whether file descriptors are closed properly.
-
-        This test targets the following issue:
-
-        `Pulp #4073 <https://pulp.plan.io/issues/4073>`_
-
-        Do the following:
-
-        1. Check if 'lsof' is installed. If it is not, skip this test.
-        2. Create and sync a repo.
-        3. Run the 'lsof' command to verify that files in the
-           path ``/var/lib/pulp/`` are closed after the sync.
-        4. Assert that issued command returns `0` opened files.
-        """
-        cli_client = cli.Client(self.cfg, cli.echo_handler)
-        repo_api = deb_repository_api
-        remote_api = deb_remote_api
-
-        # check if 'lsof' is available
-        if cli_client.run(("which", "lsof")).returncode != 0:
-            raise unittest.SkipTest("lsof package is not present")
-
-        repo = repo_api.create(gen_repo())
-        self.addCleanup(repo_api.delete, repo.pulp_href)
-
-        remote = remote_api.create(gen_deb_remote())
-        self.addCleanup(remote_api.delete, remote.pulp_href)
-
-        repository_sync_data = RepositorySyncURL(remote=remote.pulp_href)
-        sync_response = repo_api.sync(repo.pulp_href, repository_sync_data)
-        monitor_task(sync_response.task)
-
-        cmd = "lsof -t +D {}".format(MEDIA_PATH).split()
-        response = cli_client.run(cmd).stdout
-        self.assertEqual(len(response), 0, response)
 
 
 class SyncInvalidTestCase(unittest.TestCase):


### PR DESCRIPTION
Changes in file pulp_deb/tests/functional/api/test_sync.py according to
https://www.redhat.com/archives/pulp-dev/2020-September/msg00013.html