### PR TITLE
Set default for DJANGO_SETTINGS_MODULE

### DIFF
--- a/pulp_deb/tests/functional/setup_signing_service.py
+++ b/pulp_deb/tests/functional/setup_signing_service.py
@@ -14,6 +14,8 @@ if __name__ == "__main__":
         print("Usage: {} <path_to_signing_script>".format(sys.argv[0]))
         sys.exit(1)
 
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
+
     import django
 
     django.setup()


### PR DESCRIPTION
This sets a default for DJANGO_SETTINGS_MODULE which means the user doesn't have to specify it anymore. Since it's a default, the user can still override it. This follows recent commits to pulpcore itself.