### PR TITLE
Rename the master branch to main

### DIFF
--- a/.github/workflows/scripts/before_install.sh
+++ b/.github/workflows/scripts/before_install.sh
@@ -52,7 +52,7 @@ if [[ -n $(echo -e $COMMIT_MSG | grep -P "Required PR:.*" | grep -v "https") ]];
   exit 1
 fi
 
-if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "${BRANCH_BUILD}" = "1" -a "${BRANCH}" != "master" ]
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "${BRANCH_BUILD}" = "1" -a "${BRANCH}" != "main" ]
 then
   export PULPCORE_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulpcore\/pull\/(\d+)' | awk -F'/' '{print $7}')
   export PULP_SMASH_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-smash\/pull\/(\d+)' | awk -F'/' '{print $7}')

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -11,7 +11,7 @@ To contribute to the ``pulp_deb`` plugin follow this process:
 3. Make sure all tests passed
 4. Add a file into CHANGES folder (Changelog update).
 5. Commit changes to own ``pulp_deb`` clone
-6. Make pull request from github page for your clone against master branch
+6. Make pull request from github page for your clone against the ``main`` branch
 
 
 Changelog Update

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pulp_deb
 
-![master status](https://github.com/pulp/pulp_deb/workflows/Pulp%20CI/badge.svg)
+![main branch status](https://github.com/pulp/pulp_deb/workflows/Pulp%20CI/badge.svg)
 ![release status](https://github.com/pulp/pulp_deb/workflows/Pulp%20Release%20CI/CD/badge.svg)
 ![python versions](https://img.shields.io/pypi/pyversions/pulp_deb.svg)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
+# The top level toctree document.
 master_doc = 'index'
 
 # General information about the project.

--- a/docs/external_references.rst
+++ b/docs/external_references.rst
@@ -37,9 +37,9 @@
 .. _try OpenAPI generator:
    https://openapi-generator.tech/#try
 .. _signing service setup script:
-   https://github.com/pulp/pulp_deb/blob/master/pulp_deb/tests/functional/setup_signing_service.py
+   https://github.com/pulp/pulp_deb/blob/main/pulp_deb/tests/functional/setup_signing_service.py
 .. _signing service script example:
-   https://github.com/pulp/pulp_deb/blob/master/pulp_deb/tests/functional/sign_deb_release.sh
+   https://github.com/pulp/pulp_deb/blob/main/pulp_deb/tests/functional/sign_deb_release.sh
 .. _pulp plugin template:
    https://github.com/pulp/plugin_template
 .. _pulplift:

--- a/docs/plugin_maintenance.rst
+++ b/docs/plugin_maintenance.rst
@@ -81,7 +81,7 @@ It may need to be amended to reflect changes in the release process for pulpcore
 .. note::
    The plugin is released to pypi.org as the `pulp_deb python package`_.
    In addition a new `pulp-deb-client package`_ and `pulp_deb_client Ruby Gem`_ will be released.
-   Client packages based on the latest plugin master branch are also released daily.
+   Client packages based on the latest plugin ``main`` branch are also released daily.
    See the :ref:`plugin template <using_the_plugin_template>` and the ``template_config.yml`` file for more information on those independent releases.
 
 .. note::
@@ -138,11 +138,11 @@ For a ``X`` or a ``Y`` release, perform the following steps (the example assumes
       This presupposes that we have already removed any dependencies on any deprecations announced for pulpcore ``3.8``.
       See `pulpcore plugin API deprecation policy`_ for more information.
 
-      The lower bound should be changed directly in master whenever some change actually requires a newer pulpcore version.
-      Therefore it should not normally be necessary to raise this at release time (beyond what it already was in master).
+      The lower bound should be changed directly in the ``main`` branch whenever some change actually requires a newer pulpcore version.
+      Therefore it should not normally be necessary to raise this at release time (beyond what it already was in the ``main`` branch).
 
 #. Create a PR for the ``release_2.8.0`` branch generated in step 2.
-#. Review and merge the PR to ``master`` (make sure the tests on ``master`` turn green post merge).
+#. Review and merge the PR to ``main`` (make sure the tests on ``main`` turn green post merge).
 #. Create the ``2.8`` release branch (with the ``Releasing 2.8.0`` commit checked out).
    The branch needs to be pushed directly into the upstream repository.
 #. On the ``2.8`` release branch, manually bump the version from ``2.8.0`` to ``2.8.1.dev`` in ``.bumpversion.cfg``, ``pulp_deb/__init__.py``, and  ``setup.py``.
@@ -179,10 +179,10 @@ For a ``Z`` release, perform the following steps (the example assumes we are rel
    For the release script to do the right thing, they need to be provided, even though they should not be changed for ``Z`` releases.
 
 #. Create a PR for the ``release_2.8.1`` branch generated in step 2.
-   It needs to go into the ``2.8`` branch, not ``master``!
+   It needs to go into the ``2.8`` branch, not ``main``!
 #. Review and merge the PR.
-#. Switch back to ``master``, and ``git cherry-pick -x`` the ``Building changelog for 2.8.1`` commit from the ``2.8`` release branch.
-   Push directly to master or create and merge a PR for it.
+#. Switch back to ``main``, and ``git cherry-pick -x`` the ``Building changelog for 2.8.1`` commit from the ``2.8`` release branch.
+   Push directly to ``main`` or create and merge a PR for it.
 #. Trigger the release by creating and pushing the ``2.8.1`` release tag at the ``Releasing 2.8.1`` commit (on the ``2.8`` release branch).
 #. Check the `pulp_deb GitHub actions pipelines`_, the `pulp_deb python package`_, the `pulp-deb-client package`_, and the `pulp_deb_client Ruby Gem`_ to see if everything has released correctly.
    Also check the :ref:`changelog <changelog>` of this documentation to make sure it was also updated.


### PR DESCRIPTION
[noissue]

With this change, I will need to push a new branch `main`, change the repositories default branch to it, add the branch protection rule, and finally delete the `master` branch.

- [x] Add `main` branch to the repo.
- [x] Add branch protection for the `main` branch.
- [ ] Merge this PR to the new `main` branch.
- [ ] Make the `main` branch the default branch.
- [ ] Unprotect and delete the `master` branch.