### PR TITLE
Add a list of the most important URLs to the docs

### DIFF
--- a/docs/external_references.rst
+++ b/docs/external_references.rst
@@ -10,6 +10,8 @@
    https://docs.pulpproject.org/installation/index.html
 .. _pulpcore plugin API deprecation policy:
    https://docs.pulpproject.org/pulpcore/plugins/plugin-writer/concepts/index.html#plugin-api-stability-and-deprecation-policy
+.. _pulp_deb issue tracker:
+   https://pulp.plan.io/projects/pulp_deb/issues/
 .. _pulp_deb milestone:
    https://pulp.plan.io/projects/pulp_deb/roadmap
 .. _pulpcore release guide:
@@ -36,6 +38,8 @@
    https://openapi-generator.tech/docs/generators
 .. _try OpenAPI generator:
    https://openapi-generator.tech/#try
+.. _pulp_deb source repository:
+   https://github.com/pulp/pulp_deb
 .. _signing service setup script:
    https://github.com/pulp/pulp_deb/blob/main/pulp_deb/tests/functional/setup_signing_service.py
 .. _signing service script example:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,16 @@ If you are just getting started with the plugin, read the high level :ref:`featu
 See :ref:`workflows <workflows>` for detailed usage examples.
 See the :ref:`REST API <rest_api>` documentation for an exhaustive feature reference.
 
+The most important places relating to this project:
+
+* The `Pulp Project`_ homepage.
+* The `pulpcore documentation`_.
+* The `pulp_deb issue tracker`_.
+* The `pulp_deb source repository`_.
+* The `pulp_deb python package`_.
+* The `pulp-deb-client package`_ (contains API bindings for Python).
+* The `pulp_deb_client Ruby Gem`_ (contains API bindings for Ruby).
+
 
 Table of Contents
 --------------------------------------------------------------------------------


### PR DESCRIPTION
[noissue]

I frequently find myself wanting to navigate from the docs to one or more of these places.

Some of these URLs are already available embedded within text, but IMHO a list is more user friendly to returning users.