### PR TITLE
Fix CI signing service creation

### DIFF
--- a/.github/workflows/scripts/post_before_script.sh
+++ b/.github/workflows/scripts/post_before_script.sh
@@ -5,12 +5,13 @@ then
   # Add signing service script and setup script:
   cat pulp_deb/tests/functional/sign_deb_release.sh | cmd_stdin_prefix bash -c "cat > /root/sign_deb_release.sh"
   cat pulp_deb/tests/functional/setup_signing_service.py | cmd_stdin_prefix bash -c "cat > /tmp/setup_signing_service.py"
+  curl -L https://github.com/pulp/pulp-fixtures/raw/master/common/GPG-KEY-pulp-qe | cmd_stdin_prefix bash -c "cat > /tmp/GPG-KEY-pulp-qe"
 
   # Add private pulp-qe test key and set ownertrust:
   curl -L https://github.com/pulp/pulp-fixtures/raw/master/common/GPG-PRIVATE-KEY-pulp-qe | cmd_stdin_prefix gpg --import
   echo "6EDF301256480B9B801EBA3D05A5E6DA269D9D98:6:" | cmd_stdin_prefix gpg --import-ownertrust
 
   # Create the signing service:
-  cmd_prefix chmod a+x /tmp/setup_signing_service.py /root/sign_deb_release.sh
+  cmd_prefix chmod a+x /tmp/setup_signing_service.py /root/sign_deb_release.sh /tmp/GPG-KEY-pulp-qe
   cmd_prefix /tmp/setup_signing_service.py /root/sign_deb_release.sh
 fi

--- a/pulp_deb/tests/functional/setup_signing_service.py
+++ b/pulp_deb/tests/functional/setup_signing_service.py
@@ -5,13 +5,19 @@ import sys
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: {} <path_to_signing_script>".format(sys.argv[0]))
+
+    usage_string = "Usage: {} <path_to_signing_script> <path_to_public_key_file>".format(
+        sys.argv[0]
+    )
+
+    if len(sys.argv) != 3:
+        print(usage_string)
         sys.exit(1)
 
     script_path = os.path.realpath(sys.argv[1])
-    if not os.path.exists(script_path):
-        print("Usage: {} <path_to_signing_script>".format(sys.argv[0]))
+    public_key_file = os.path.realpath(sys.argv[2])
+    if not os.path.exists(script_path) or not os.path.exists(public_key_file):
+        print(usage_string)
         sys.exit(1)
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
@@ -22,7 +28,12 @@ if __name__ == "__main__":
 
     from pulp_deb.app.models import AptReleaseSigningService
 
+    with open(public_key_file, "rb") as key:
+        public_key = key.read()
+
     AptReleaseSigningService.objects.create(
         name="sign_deb_release",
         script=script_path,
+        public_key=public_key,
+        pubkey_fingerprint="6EDF301256480B9B801EBA3D05A5E6DA269D9D98",
     )


### PR DESCRIPTION
[noissue]

This is a minimal intervention to fix the CI tests.
It does NOT amend the actual SigningService to fix the underlying deprecation.
I intend to do that on a separate PR, once working CI pipelines have been restored.