### PR TITLE
Handle ALLOWED_CONTENT_CHECKSUMS parameter

### DIFF
--- a/CHANGES/8388.bugfix
+++ b/CHANGES/8388.bugfix
@@ -1,0 +1,1 @@
+Ensured the plugin respects the ALLOWED_CONTENT_CHECKSUMS setting.

--- a/CHANGES/8388.doc
+++ b/CHANGES/8388.doc
@@ -1,0 +1,1 @@
+Added workflow documentation on checksum handling configuration.

--- a/docs/external_references.rst
+++ b/docs/external_references.rst
@@ -2,12 +2,18 @@
    https://docs.pulpproject.org
 .. _flat repository format:
    https://wiki.debian.org/DebianRepository/Format#Flat_Repository_Format
+.. _release file format:
+   https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files
 .. _pulpcore metadata signing docs:
    https://docs.pulpproject.org/workflows/signed-metadata.html
 .. _pulpcore upload documentation:
    https://docs.pulpproject.org/workflows/upload-publish.html
 .. _pulpcore installation:
    https://docs.pulpproject.org/installation/index.html
+.. _pulpcore configuration documentation:
+   https://docs.pulpproject.org/pulpcore/installation/configuration.html
+.. _pulpcore settings documentation:
+   https://docs.pulpproject.org/pulpcore/settings.html#pulp-settings
 .. _pulpcore plugin API deprecation policy:
    https://docs.pulpproject.org/pulpcore/plugins/plugin-writer/concepts/index.html#plugin-api-stability-and-deprecation-policy
 .. _pulp_deb issue tracker:

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -18,6 +18,7 @@ This chapter is structured into the following subsections:
 .. toctree::
    :maxdepth: 2
 
+   workflows/checksums
    workflows/sync
    workflows/upload
    workflows/publish

--- a/docs/workflows/checksums.rst
+++ b/docs/workflows/checksums.rst
@@ -1,0 +1,71 @@
+.. _checksums:
+
+Configure Checksum Handling
+================================================================================
+
+.. include:: ../external_references.rst
+
+``pulp_deb`` supports the following checksum algorithms: MD5, SHA-1, SHA-256, and SHA-512.
+However, only algorithms that are present in the ``ALLOWED_CONTENT_CHECKSUMS`` setting will actually be used.
+
+.. warning::
+   Starting with pulpcore version 3.11, pulpcore will remove ``md5`` and ``sha1`` from the list of ``ALLOWED_CONTENT_CHECKSUMS`` by default.
+   At that point, those checksums will no longer be available for use by the ``pulp_deb`` plugin, unless users explicitly opt back in.
+   Without opt in, the ``pulp_deb`` plugin will be unable to include the relevant metadata fields (``MD5Sum``, and ``SHA1``) in any metadata files (such as release files and package indecies), published by the plugin's APT publisher.
+   Since it is almost universal practice within the Debian ecosystem to publish MD5 in particular, there is no telling what might break without it.
+   As a result, it is recommended most ``pulp_deb`` users opt in to at least MD5.
+   If you are unable to enable MD5 for compliance reasons, or if you are feeling adventurous, you are welcome to put the claim that MD5 is merely "highly recommended" to the test.
+
+   See the `release file format`_ description in the Debian Wiki for more information.
+
+
+Background: What are the checksums used for?
+--------------------------------------------------------------------------------
+
+APT repository metadata files (release files and package indecies) will typically include several checksums for all files that they reference.
+During synchronization, ``pulp_deb`` will check the downloaded files against the checksums provided (so long as the checksum type is one of the supported algorithms and is present in the ``ALLOWED_CONTENT_CHECKSUMS`` setting).
+Together with a valid (and trusted) release file signature this will guarantee the integrity of the synchronized repository.
+
+During publication, the APT publisher will include any supported (and permitted) checksumtypes in any metadata files it publishes.
+
+.. warning::
+   While the APT publisher will respect the ``ALLOWED_CONTENT_CHECKSUMS`` setting, the verbatim publisher will publish the upstream metadata files *verbatim* (the exact same metadata file that was synchronized).
+   As a result, the verbatim publisher is totally independent of (and does not respect) the ``ALLOWED_CONTENT_CHECKSUMS`` setting.
+   If your policy prohibits the presence of certain checksum types, either do not use the verbatim publisher, or only synchronize repositories that are already compliant with your policy.
+
+
+Opting in to MD5 and/or SHA1
+--------------------------------------------------------------------------------
+
+.. note::
+   Up to pulpcore version 3.11 all supported checksums were enabled by default.
+   In addition all ``pulp_deb`` versions compatible with pulpcore up to 3.11 simply break if the user actively disables any of the checksum types supported by the plugin.
+
+To opt in to MD5 and SHA1 checksum handling users simply need to manually configure the ``ALLOWED_CONTENT_CHECKSUMS`` setting in the Pulp configuration file (normally found at ``/etc/pulp/settings.py``).
+
+See the `pulpcore configuration documentation`_ for more information on configuration files and look for the section on ``ALLOWED_CONTENT_CHECKSUMS`` in the `pulpcore settings documentation`_ for more information on this setting.
+
+Once you have updated your configuration file you will likely need to halt your Pulp instance, and then run the following command to ensure your DB is made consistent with your ``ALLOWED_CONTENT_CHECKSUMS`` setting:
+
+.. code-block:: none
+
+   pulpcore-manager handle-artifact-checksums
+
+.. note::
+   Missing checksums will need to be recalculated for all your artifacts which can take some time.
+   If you have a missmatch between your configured ``ALLOWED_CONTENT_CHECKSUMS`` setting and the checksums present in the DB, Pulp will simply refuse to start.
+
+
+Security Implications
+--------------------------------------------------------------------------------
+
+While the MD5 and SHA-1 algorithms are no longer considered secure, ``pulp_deb`` *requires* the presence of SHA-256 checksums to function, and is therefore *never* dependent on unsecure algorithms for integrity checking.
+MD5 and SHA-1 are checked and used *in addition* to the other algorithms, purely for backwards compatibility.
+This is consistent with widespread usage within the larger Debian ecosystem.
+
+
+Disabling forbidden checksum warnings
+--------------------------------------------------------------------------------
+
+If your Pulp instance is configured to disallow the MD5 checksum algorithm, ``pulp_deb`` will emit a warning message with every sync as well as every use of the APT publisher.
+You can disable these warnings, by setting ``FORBIDDEN_CHECKSUM_WARNINGS = False`` in your Pulp configuration file.

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -275,14 +275,18 @@ class BasePackage822Serializer(SingleArtifactContentSerializer):
 
         try:
             artifact = self.instance._artifacts.get()
-            ret["MD5sum"] = artifact.md5
-            ret["SHA1"] = artifact.sha1
+            if artifact.md5:
+                ret["MD5sum"] = artifact.md5
+            if artifact.sha1:
+                ret["SHA1"] = artifact.sha1
             ret["SHA256"] = artifact.sha256
         except Artifact.DoesNotExist:
-            remote_artifact = RemoteArtifact.objects.filter(sha256=self.instance.sha256).first()
-            ret["MD5sum"] = remote_artifact.md5
-            ret["SHA1"] = remote_artifact.sha1
-            ret["SHA256"] = remote_artifact.sha256
+            artifact = RemoteArtifact.objects.filter(sha256=self.instance.sha256).first()
+            if artifact.md5:
+                ret["MD5sum"] = artifact.md5
+            if artifact.sha1:
+                ret["SHA1"] = artifact.sha1
+            ret["SHA256"] = artifact.sha256
 
         ret["Filename"] = self.instance.filename(component)
 

--- a/pulp_deb/app/settings.py
+++ b/pulp_deb/app/settings.py
@@ -4,3 +4,5 @@ Check `Plugin Writer's Guide`_ for more details.
 .. _Plugin Writer's Guide:
     http://docs.pulpproject.org/en/3.0/nightly/plugins/plugin-writer/index.html
 """
+
+FORBIDDEN_CHECKSUM_WARNINGS = True

--- a/pulp_deb/constants.py
+++ b/pulp_deb/constants.py
@@ -1,0 +1,13 @@
+NO_MD5_WARNING_MESSAGE = (
+    "Your pulp instance is configured to prohibit use of the MD5 checksum algorithm!\n"
+    'Processing MD5 IN ADDITION to a secure hash like SHA-256 is "highly recommended".\n'
+    "See https://docs.pulpproject.org/pulp_deb/workflows/checksums.html for more info.\n"
+)
+
+# Maps pulpcore names onto Debian metadata field names for all supported checksums:
+CHECKSUM_MAP = {
+    "md5": "MD5sum",
+    "sha1": "SHA1",
+    "sha256": "SHA256",
+    "sha512": "SHA512",
+}


### PR DESCRIPTION
fixes #8388
https://pulp.plan.io/issues/8388

TODO:
- [ ] test both with md5, sha1 enabled as well as disabled
- [x] Add WARNINGS when md5 is disabled plus ability to disable the warning
- [x] documentation