### PR TITLE
Backport 2.10: Fix translation file synchronization

### DIFF
--- a/CHANGES/8558.bugfix
+++ b/CHANGES/8558.bugfix
@@ -1,0 +1,2 @@
+Fixed the relative paths for translation files, which were causing sync failures and missing translation files.
+(Backported from https://pulp.plan.io/issues/8410)

--- a/pulp_deb/app/tasks/synchronizing.py
+++ b/pulp_deb/app/tasks/synchronizing.py
@@ -668,7 +668,7 @@ class DebFirstStage(Stage):
         paths = [path for path in file_references.keys() if path.startswith(translation_dir)]
         translations = {}
         for path in paths:
-            relative_path = os.path.join(os.path.dirname(release_file.relative_path))
+            relative_path = os.path.join(os.path.dirname(release_file.relative_path), path)
             d_artifact = self._to_d_artifact(relative_path, file_references[path])
             key, ext = os.path.splitext(relative_path)
             if key not in translations:


### PR DESCRIPTION
Fixes #8558
Backports #8410

https://pulp.plan.io/issues/8558
https://pulp.plan.io/issues/8410
https://pulp.plan.io/issues/8096

(cherry picked from commit 580f0e725a3a47e181eb582fbe8ba33a35c5b1e6)