### PR TITLE
Completely disable synchronization of translation files

### DIFF
--- a/CHANGES/8671.bugfix
+++ b/CHANGES/8671.bugfix
@@ -1,0 +1,1 @@
+Completely disabled translation file synchronization to prevent sync failures.

--- a/pulp_deb/app/tasks/synchronizing.py
+++ b/pulp_deb/app/tasks/synchronizing.py
@@ -506,10 +506,6 @@ class DebFirstStage(Stage):
                     for architecture in architectures
                 ]
             )
-        # Handle translation files
-        pending_tasks.append(
-            self._handle_translation_files(release_file, release_component, file_references)
-        )
         if self.remote.sync_sources:
             raise NotImplementedError("Syncing source repositories is not yet implemented.")
         await asyncio.gather(*pending_tasks)


### PR DESCRIPTION
Closes #8671
https://pulp.plan.io/issues/8671

This feature has never fully worked, the implementation is incomplete
and causes various sync failures. Re-adding this feature should be done
under the following story: https://pulp.plan.io/issues/8734