### PR TITLE
Backport 2.11: Completely disable synchronization of translation files

### DIFF
--- a/CHANGES/8736.bugfix
+++ b/CHANGES/8736.bugfix
@@ -1,0 +1,2 @@
+Completely disabled translation file synchronization to prevent sync failures.
+(Backported from https://pulp.plan.io/issues/8671)

--- a/pulp_deb/app/tasks/synchronizing.py
+++ b/pulp_deb/app/tasks/synchronizing.py
@@ -506,10 +506,6 @@ class DebFirstStage(Stage):
                     for architecture in architectures
                 ]
             )
-        # Handle translation files
-        pending_tasks.append(
-            self._handle_translation_files(release_file, release_component, file_references)
-        )
         if self.remote.sync_sources:
             raise NotImplementedError("Syncing source repositories is not yet implemented.")
         await asyncio.gather(*pending_tasks)


### PR DESCRIPTION
Closes #8736
Backports #8671
https://pulp.plan.io/issues/8671

This feature has never fully worked, the implementation is incomplete
and causes various sync failures. Re-adding this feature should be done
under the following story: https://pulp.plan.io/issues/8734

(cherry picked from commit 98f25d846f41fc817501451daef39118d18d06b2)