### PR TITLE
Consider that release file components may not be plain components

### DIFF
--- a/CHANGES/8828.bugfix
+++ b/CHANGES/8828.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where components from the remote were being ignored when specified as the plain component.


### PR DESCRIPTION
Closes #8828
https://pulp.plan.io/issues/8828

When creating an intersection between the release file components and
the components from the remote, we need to consider the special case,
where the release file components have a path prefix, but those from the 
remote do not!