### PR TITLE
Make flat repo syncs more robust

### DIFF
--- a/CHANGES/7673.bugfix
+++ b/CHANGES/7673.bugfix
@@ -1,0 +1,1 @@
+Flat repo syncs were made more robust with respect to minimal release files.

--- a/pulp_deb/app/models/content.py
+++ b/pulp_deb/app/models/content.py
@@ -72,10 +72,9 @@ class PackageIndex(Content):
     """
     The "PackageIndex" content type.
 
-    This model represents the Packages file for a specific
-    component - architecture combination.
-    It's artifacts should include all (non-)compressed versions
-    of the upstream Packages file.
+    This model represents the Packages file(s) for a specific component - architecture combination
+    (or an entire flat repo). The artifacts will always include the uncompressed Packages file, as
+    well as any compressed package indices using an archive format supported by pulp_deb.
     """
 
     TYPE = "package_index"

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -127,11 +127,11 @@ class PackageIndexSerializer(MultipleArtifactContentSerializer):
     """
 
     component = CharField(
-        help_text="Component of the component - architecture combination.", required=True
+        help_text="Component of the component - architecture combination.", required=False
     )
 
     architecture = CharField(
-        help_text="Architecture of the component - architecture combination.", required=True
+        help_text="Architecture of the component - architecture combination.", required=False
     )
 
     relative_path = CharField(help_text="Path of file relative to url.", required=False)

--- a/pulp_deb/tests/functional/api/test_publish_flat_repo_format.py
+++ b/pulp_deb/tests/functional/api/test_publish_flat_repo_format.py
@@ -56,11 +56,13 @@ class FlatRepoSyncTestCase(unittest.TestCase):
             "distribution": "/",
             "codename": "ragnarok",
             "suite": "mythology",
-            "components": ["asgard"],
+            "components": ["flat-repo-component"],
             "release_file_folder_sync": "",
-            "release_file_folder_dist": "dists",
+            "release_file_folder_dist": "dists/flat-repo",
             "package_index_paths_sync": ["Packages"],
-            "package_index_paths_dist": ["dists/asgard/binary-ppc64/Packages"],
+            "package_index_paths_dist": [
+                "dists/flat-repo/flat-repo-component/binary-ppc64/Packages"
+            ],
         }
         self.do_publish(expected_values, "structured")
 
@@ -70,7 +72,7 @@ class FlatRepoSyncTestCase(unittest.TestCase):
             "distribution": "/",
             "codename": "ragnarok",
             "suite": "mythology",
-            "components": ["asgard"],
+            "components": ["flat-repo-component"],
             "release_file_folder_sync": "",
             "release_file_folder_dist": "dists/default/",
             "package_index_paths_sync": ["Packages"],
@@ -84,7 +86,7 @@ class FlatRepoSyncTestCase(unittest.TestCase):
             "distribution": "/",
             "codename": "ragnarok",
             "suite": "mythology",
-            "components": ["asgard"],
+            "components": ["flat-repo-component"],
             "release_file_folder_sync": "",
             "release_file_folder_dist": "/",
             "package_index_paths_sync": ["Packages"],
@@ -98,11 +100,13 @@ class FlatRepoSyncTestCase(unittest.TestCase):
             "distribution": "nest/fjalar/",
             "codename": "ragnarok",
             "suite": "mythology",
-            "components": ["asgard"],
+            "components": ["flat-repo-component"],
             "release_file_folder_sync": "nest/fjalar/",
             "release_file_folder_dist": "dists/nest/fjalar",
             "package_index_paths_sync": ["nest/fjalar/Packages"],
-            "package_index_paths_dist": ["dists/nest/fjalar/asgard/binary-ppc64/Packages"],
+            "package_index_paths_dist": [
+                "dists/nest/fjalar/flat-repo-component/binary-ppc64/Packages"
+            ],
         }
         self.do_publish(expected_values, "structured")
 
@@ -112,7 +116,7 @@ class FlatRepoSyncTestCase(unittest.TestCase):
             "distribution": "nest/fjalar/",
             "codename": "ragnarok",
             "suite": "mythology",
-            "components": ["asgard"],
+            "components": ["flat-repo-component"],
             "release_file_folder_sync": "nest/fjalar/",
             "release_file_folder_dist": "dists/default/",
             "package_index_paths_sync": ["nest/fjalar/Packages"],
@@ -126,7 +130,7 @@ class FlatRepoSyncTestCase(unittest.TestCase):
             "distribution": "nest/fjalar/",
             "codename": "ragnarok",
             "suite": "mythology",
-            "components": ["asgard"],
+            "components": ["flat-repo-component"],
             "release_file_folder_sync": "nest/fjalar/",
             "release_file_folder_dist": "nest/fjalar/",
             "package_index_paths_sync": ["nest/fjalar/Packages"],


### PR DESCRIPTION
Closes #7673
https://pulp.plan.io/issues/7673

With this change flat repo syncs will work even if the upstream Release
file contains no "Components" or "Architectures" fields. In addition we
are ensuring flat repo syncs do not attempt to sync installer files or
packages.