### PR TITLE
Add touch statements to prevent false positives during orphan cleanup

### DIFF
--- a/CHANGES/9162.misc
+++ b/CHANGES/9162.misc
@@ -1,0 +1,1 @@
+Added touch statements to prevent false positives during orphan cleanup.

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -72,6 +72,7 @@ class GenericContentSerializer(SingleArtifactContentUploadSerializer, ContentChe
             sha256=data["sha256"], relative_path=data["relative_path"]
         )
         if content.exists():
+            content.first().touch()  # Orphan cleanup protection so the user has a chance to use it!
             raise ValidationError(
                 _(
                     "There is already a generic content with relative path '{path}' and sha256 "
@@ -275,6 +276,7 @@ class BasePackage822Serializer(SingleArtifactContentSerializer):
 
         try:
             artifact = self.instance._artifacts.get()
+            artifact.touch()  # Orphan cleanup protection until we are done!
             if artifact.md5:
                 ret["MD5sum"] = artifact.md5
             if artifact.sha1:
@@ -408,12 +410,14 @@ class BasePackageSerializer(SingleArtifactContentUploadSerializer, ContentChecks
         elif not os.path.basename(data["relative_path"]) == "{}.{}".format(
             self.Meta.model(**package_data).name, self.Meta.model.SUFFIX
         ):
+            data["artifact"].touch()  # Orphan cleanup protection so the user can try again!
             raise ValidationError(_("Invalid relative_path provided, filename does not match."))
 
         content = self.Meta.model.objects.filter(
             sha256=data["sha256"], relative_path=data["relative_path"]
         )
         if content.exists():
+            content.first().touch()  # Orphan cleanup protection so the user has a chance to use it!
             raise ValidationError(
                 _(
                     "There is already a deb package with relative path '{path}' and sha256 "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pulpcore>=3.12
+pulpcore>=3.14
 python-debian>=0.1.36


### PR DESCRIPTION
Closes #9162
https://pulp.plan.io/issues/9162