### PR TITLE
Fix  db migration doc

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,8 +36,8 @@ Make and Run Migrations
 
 .. code-block:: bash
 
-   pulp-manager makemigrations pulp_deb
-   pulp-manager migrate pulp_deb
+   pulpcore-manager makemigrations deb
+   pulpcore-manager migrate deb
 
 
 Run Services


### PR DESCRIPTION
Installation guide seems obsolete on db migration
instructions.

Signed-off-by: ushen <yshxxsjt715@gmail.com>