### PR TITLE
Backport to 2.13: Add missing "Size" field in publications

### DIFF
--- a/CHANGES/9167.bugfix
+++ b/CHANGES/9167.bugfix
@@ -1,0 +1,2 @@
+Add missing "Size" field in publications
+(backported from #8506)

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,2 +1,3 @@
 pulp-smash @ git+https://github.com/pulp/pulp-smash.git
 pytest
+python-debian>=0.1.36

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -280,6 +280,7 @@ class BasePackage822Serializer(SingleArtifactContentSerializer):
             if artifact.sha1:
                 ret["SHA1"] = artifact.sha1
             ret["SHA256"] = artifact.sha256
+            ret["Size"] = str(artifact.size)
         except Artifact.DoesNotExist:
             artifact = RemoteArtifact.objects.filter(sha256=self.instance.sha256).first()
             if artifact.md5:
@@ -287,6 +288,7 @@ class BasePackage822Serializer(SingleArtifactContentSerializer):
             if artifact.sha1:
                 ret["SHA1"] = artifact.sha1
             ret["SHA256"] = artifact.sha256
+            ret["Size"] = str(artifact.size)
 
         ret["Filename"] = self.instance.filename(component)
 

--- a/pulp_deb/app/tasks/synchronizing.py
+++ b/pulp_deb/app/tasks/synchronizing.py
@@ -570,7 +570,9 @@ class DebFirstStage(Stage):
                 )
                 package_path = os.path.join(self.parsed_url.path, package_relpath)
                 package_da = DeclarativeArtifact(
-                    artifact=Artifact(**_get_checksums(package_paragraph)),
+                    artifact=Artifact(
+                        size=int(package_paragraph["Size"]), **_get_checksums(package_paragraph)
+                    ),
                     url=urlunparse(self.parsed_url._replace(path=package_path)),
                     relative_path=package_relpath,
                     remote=self.remote,

--- a/pulp_deb/tests/unit/test_models.py
+++ b/pulp_deb/tests/unit/test_models.py
@@ -19,6 +19,7 @@ class TestPackage(TestCase):
         "MD5sum: aabb\n"
         "SHA1: ccdd\n"
         "SHA256: eeff\n"
+        "Size: 42\n"
         "Filename: pool/a/aegir/aegir_0.1-edda0_sea.deb\n"
     )
 


### PR DESCRIPTION
also added some more detailed tests for published package-indizes
backports #8506
https://pulp.plan.io/issues/8506

fixes #9167

(cherry picked from commit f4172f489c59022fa93256b5781ec34eae8bef99)