### PR TITLE
Disable changelog to main branch CI jobs for 2.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,23 +276,3 @@ jobs:
 
       - name: Create release on GitHub
         run: bash .github/workflows/scripts/create_release_from_tag.sh ${{ github.event.inputs.release }}
-
-      - name: Cleanup repository before making changelog PR
-        run: rm -rf .lock generation pulp_deb_client* *-client.tar pulp_deb.tar todo web docs.tar
-
-      - name: Stage changelog for master branch
-        run: python .github/workflows/scripts/stage-changelog-for-master.py ${{ github.event.inputs.release }}
-
-      - name: Create Pull Request for Changelog
-        uses: peter-evans/create-pull-request@v3
-        with:
-          committer: pulpbot <pulp-infra@redhat.com>
-          author: pulpbot <pulp-infra@redhat.com>
-          branch: ${{ github.event.inputs.release }}-changelog
-          base: main
-          title: 'Building changelog for ${{ github.event.inputs.release }}'
-          body: '[noissue]'
-          commit-message: |
-            Building changelog for ${{ github.event.inputs.release }}
-            [noissue]
-          delete-branch: true


### PR DESCRIPTION
[noissue]

With the way I have been handling changelog for pulp_deb, this job is
doomed to fail for older release branches (unresolvable merge conflict)!
I will do this manually instead.