### PR TITLE
Pin python-debian to <0.1.42 to prevent breakage against python <3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pulpcore>=3.14,<3.16
 python-debian>=0.1.36
+python-debian<0.1.42


### PR DESCRIPTION
[noissue]