### PR TITLE
Fix mirrored metadata handling when creating new repo versions

### DIFF
--- a/CHANGES/8756.bugfix
+++ b/CHANGES/8756.bugfix
@@ -1,0 +1,1 @@
+Fixed mirrored metadata handling when creating a new repository version.

--- a/pulp_deb/app/models/repository.py
+++ b/pulp_deb/app/models/repository.py
@@ -42,6 +42,17 @@ class AptRepository(Repository):
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
 
+    def initialize_new_version(self, new_version):
+        """
+        Remove old metadata from the repo before performing anything else for the new version. This
+        way, we ensure any syncs will re-add all metadata relevant for the latest sync, but old
+        metadata (which may no longer be appropriate for the new RepositoryVersion is never
+        retained.
+        """
+        new_version.remove_content(ReleaseFile.objects.all())
+        new_version.remove_content(PackageIndex.objects.all())
+        new_version.remove_content(InstallerFileIndex.objects.all())
+
     def finalize_new_version(self, new_version):
         """
         Finalize and validate the new repository version.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pulpcore>=3.15
+pulpcore>=3.17.0.dev
 python-debian>=0.1.36


### PR DESCRIPTION
closes #8756
https://pulp.plan.io/issues/8756

In particular, this allows us to synchronize repos using mirror=false
option.

Requires https://github.com/pulp/pulpcore/pull/1726