### PR TITLE
Remove a deprecated badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # pulp_deb
 
-![main branch status](https://github.com/pulp/pulp_deb/workflows/Pulp%20CI/badge.svg)
 ![release status](https://github.com/pulp/pulp_deb/workflows/Pulp%20Release%20CI/CD/badge.svg)
 ![nightly status](https://github.com/pulp/pulp_deb/workflows/Pulp%20Nightly%20CI/CD/badge.svg)
 ![python versions](https://img.shields.io/pypi/pyversions/pulp_deb.svg)


### PR DESCRIPTION
The latest job was executed five months ago (https://github.com/pulp/pulp_deb/actions/workflows/ci.yml?query=branch%3Amain).

https://pulp.plan.io/issues/9590

[noissue]