### PR TITLE
Reference signing services via pulp_href (like everything else)

### DIFF
--- a/CHANGES/9563.bugfix
+++ b/CHANGES/9563.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug causing publications to reference any ``AptReleaseSigningService`` via a full URL instead of just a ``pulp_href``.

--- a/pulp_deb/app/serializers/publication_serializers.py
+++ b/pulp_deb/app/serializers/publication_serializers.py
@@ -1,6 +1,7 @@
-from rest_framework.serializers import BooleanField, ValidationError, HyperlinkedRelatedField
+from rest_framework.serializers import BooleanField, ValidationError
 from pulpcore.plugin.models import Publication
 from pulpcore.plugin.serializers import (
+    RelatedField,
     DistributionSerializer,
     PublicationSerializer,
     DetailRelatedField,
@@ -34,7 +35,7 @@ class AptPublicationSerializer(PublicationSerializer):
         default=False,
     )
     structured = BooleanField(help_text="Activate structured publishing mode.", default=False)
-    signing_service = HyperlinkedRelatedField(
+    signing_service = RelatedField(
         help_text="Sign Release files with this signing key",
         many=False,
         queryset=AptReleaseSigningService.objects.all(),


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jaiks@posteo.de>

fixes: https://pulp.plan.io/issues/9563