### PR TITLE
Rework No-Support-for-Architecture-all repo format sync handling

### DIFF
--- a/CHANGES/456.misc
+++ b/CHANGES/456.misc
@@ -1,0 +1,2 @@
+Reworked the sync handling for upstream repos using ``No-Support-for-Architecture-all: Packages`` format.
+This was needed to avoid clashes with the new arch filtering introduced in `#422 <https://github.com/pulp/pulp_deb/issues/422>`_.

--- a/flake8.cfg
+++ b/flake8.cfg
@@ -1,6 +1,6 @@
 [flake8]
 exclude = ./docs/*,*/migrations/*
-ignore = W503,Q000,Q003,D100,D104,D106,D200,D205,D400,D401,D402,E203
+ignore = W503,Q000,Q003,D100,D104,D106,D200,D205,D400,D401,D402,E203,D107
 max-line-length = 100
 
 # Flake8-quotes extension codes
@@ -14,6 +14,7 @@ max-line-length = 100
 # D100: missing docstring in public module
 # D104: missing docstring in public package
 # D106: missing docstring in public nested class (complains about "class Meta:" and documenting those is silly)
+# D107: Missing docstring in __init__
 # D200: one-line docstring should fit on one line with quotes
 # D205: 1 blank line required between summary line and description
 # D400: First line should end with a period

--- a/pulp_deb/tests/functional/api/test_sync.py
+++ b/pulp_deb/tests/functional/api/test_sync.py
@@ -136,7 +136,7 @@ class SyncInvalidTestCase(unittest.TestCase):
         with self.assertRaises(PulpTaskError) as exc:
             self.do_test(url=DEB_INVALID_FIXTURE_URL, architectures="ppc64")
         error = exc.exception.task.error
-        self.assertIn("No suitable Package index file", error["description"])
+        self.assertIn("No suitable package index files", error["description"])
         self.assertIn("ppc64", error["description"])
 
     def test_missing_package_indices_2(self):
@@ -149,7 +149,7 @@ class SyncInvalidTestCase(unittest.TestCase):
         with self.assertRaises(PulpTaskError) as exc:
             self.do_test(url=DEB_INVALID_FIXTURE_URL, architectures="armeb")
         error = exc.exception.task.error
-        self.assertIn("No suitable Package index file", error["description"])
+        self.assertIn("No suitable package index files", error["description"])
         self.assertIn("armeb", error["description"])
 
     def test_invalid_signature(self):


### PR DESCRIPTION
Closes #456

When a repo uses "No-Support-for-Architecture-all: Packages" style
format, we should not warn about all architecture packages in
architecture specific package indices! They are expected to be there!
We still skip those packages since there is no need to download them
twice!

When a mirror mirrors metadata indicating
"No-Support-for-Architecture-all: Packages" format, while failing to
mirror the binary-all package indices we introduce special handling to
ensure we nevertheless sync "Architecture: all" packages.