### PR TITLE
Add upper bounds to requirements for release CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pulpcore>=3.17.0,<3.20
-python-debian>=0.1.36
+python-debian>=0.1.36,<0.2.0


### PR DESCRIPTION
[noissue]

It looks like the release CI now requires upper bounds on all dependencies: https://github.com/pulp/pulp_deb/runs/6102557469?check_suite_focus=true