### PR TITLE
Raise the pulpcore floor to 3.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pulpcore>=3.17.0.dev
+pulpcore>=3.20.0.dev
 python-debian>=0.1.36,<0.2.0


### PR DESCRIPTION
This is in anticipation of the pulpcore 3.20 breaking release, for which
there are already adjustments in the pulp_deb master.