### PR TITLE
Refactor: Split up pulp_deb/app/models/content.py

### DIFF
--- a/pulp_deb/app/models/__init__.py
+++ b/pulp_deb/app/models/__init__.py
@@ -3,16 +3,18 @@
 from .content import (
     BasePackage,
     GenericContent,
-    InstallerFileIndex,
     InstallerPackage,
     Package,
-    PackageIndex,
-    PackageReleaseComponent,
+)
+
+from .structure_content import (
     Release,
     ReleaseArchitecture,
     ReleaseComponent,
-    ReleaseFile,
+    PackageReleaseComponent,
 )
+
+from .metadata_content import ReleaseFile, PackageIndex, InstallerFileIndex
 
 from .publication import AptDistribution, AptPublication, VerbatimPublication
 

--- a/pulp_deb/app/models/metadata_content.py
+++ b/pulp_deb/app/models/metadata_content.py
@@ -1,0 +1,113 @@
+from django.db import models
+
+from pulpcore.plugin.models import Content
+
+
+BOOL_CHOICES = [(True, "yes"), (False, "no")]
+
+
+class ReleaseFile(Content):
+    """
+    The "ReleaseFile" content.
+
+    This model holds an artifact to the upstream Release file.
+    """
+
+    TYPE = "release_file"
+    SUPPORTED_ARTIFACTS = ["Release", "InRelease", "Release.gpg"]
+
+    codename = models.TextField()
+    suite = models.TextField()
+    distribution = models.TextField()
+    components = models.TextField(blank=True)
+    architectures = models.TextField(blank=True)
+    relative_path = models.TextField()
+    sha256 = models.CharField(max_length=255)
+    artifact_set_sha256 = models.CharField(max_length=255)
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+        unique_together = (
+            (
+                "codename",
+                "suite",
+                "distribution",
+                "components",
+                "architectures",
+                "relative_path",
+                "sha256",
+                "artifact_set_sha256",
+            ),
+        )
+
+    @property
+    def main_artifact(self):
+        """
+        Retrieve the plain ReleaseFile artifact.
+        """
+        return self._artifacts.get(sha256=self.sha256)
+
+
+class PackageIndex(Content):
+    """
+    The "PackageIndex" content type.
+
+    This model represents the Packages file(s) for a specific component - architecture combination
+    (or an entire flat repo). The artifacts will always include the uncompressed Packages file, as
+    well as any compressed package indices using an archive format supported by pulp_deb.
+    """
+
+    TYPE = "package_index"
+    SUPPORTED_ARTIFACTS = ["Packages", "Packages.gz", "Packages.xz", "Release"]
+
+    release = models.ForeignKey(ReleaseFile, on_delete=models.CASCADE)
+    component = models.TextField()
+    architecture = models.TextField()
+    relative_path = models.TextField()
+    sha256 = models.CharField(max_length=255)
+    artifact_set_sha256 = models.CharField(max_length=255)
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+        verbose_name_plural = "PackageIndices"
+        unique_together = (("relative_path", "sha256", "artifact_set_sha256"),)
+
+    @property
+    def main_artifact(self):
+        """
+        Retrieve the uncompressed PackageIndex artifact.
+        """
+        return self._artifacts.get(sha256=self.sha256)
+
+
+class InstallerFileIndex(Content):
+    """
+    The "InstallerFileIndex" content type.
+
+    This model represents the MD5SUMS and SHA256SUMS files for a specific
+    component - architecture combination.
+    It's artifacts should include all available versions of those SUM-files
+    with the sha256-field pointing to the one with the sha256 algorithm.
+    """
+
+    TYPE = "installer_file_index"
+
+    FILE_ALGORITHM = {"SHA256SUMS": "sha256", "MD5SUMS": "md5"}  # Are there more?
+
+    release = models.ForeignKey(ReleaseFile, on_delete=models.CASCADE)
+    component = models.TextField()
+    architecture = models.TextField()
+    relative_path = models.TextField()
+    sha256 = models.CharField(max_length=255)
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+        verbose_name_plural = "InstallerFileIndices"
+        unique_together = (("relative_path", "sha256"),)
+
+    @property
+    def main_artifact(self):
+        """
+        Retrieve the uncompressed SHA256SUMS artifact.
+        """
+        return self._artifacts.get(sha256=self.sha256)

--- a/pulp_deb/app/models/structure_content.py
+++ b/pulp_deb/app/models/structure_content.py
@@ -1,0 +1,96 @@
+import os
+
+from django.db import models
+
+from pulpcore.plugin.models import Content
+
+from pulp_deb.app.models import Package
+
+
+BOOL_CHOICES = [(True, "yes"), (False, "no")]
+
+
+class Release(Content):
+    """
+    The "Release" content.
+
+    This model represents a debian release.
+    """
+
+    TYPE = "release"
+
+    codename = models.TextField()
+    suite = models.TextField()
+    distribution = models.TextField()
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+        unique_together = (("codename", "suite", "distribution"),)
+
+
+class ReleaseArchitecture(Content):
+    """
+    The ReleaseArchitecture content.
+
+    This model represents an architecture in association to a Release.
+    """
+
+    TYPE = "release_architecture"
+
+    architecture = models.TextField()
+    release = models.ForeignKey(Release, on_delete=models.CASCADE)
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+        unique_together = (("architecture", "release"),)
+
+
+class ReleaseComponent(Content):
+    """
+    The ReleaseComponent content.
+
+    This model represents a repository component in association to a Release.
+    """
+
+    TYPE = "release_component"
+
+    component = models.TextField()
+    release = models.ForeignKey(Release, on_delete=models.CASCADE)
+
+    @property
+    def plain_component(self):
+        """
+        The "plain_component" returns the component WITHOUT path prefixes.
+
+        When a Release file is not stored in a directory directly beneath "dists/",
+        the components, as stored in the Release file, may be prefixed with the
+        path following the directory beneath "dists/".
+
+        e.g.: If a Release file is stored at "REPO_BASE/dists/something/extra/Release",
+        then a component normally named "main" may be stored as "extra/main".
+
+        See also: https://wiki.debian.org/DebianRepository/Format#Components
+        """
+        return os.path.basename(self.component)
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+        unique_together = (("component", "release"),)
+
+
+class PackageReleaseComponent(Content):
+    """
+    The PackageReleaseComponent.
+
+    This is the join table that decides, which Packages (in which RepositoryVersions) belong to
+    which ReleaseComponents.
+    """
+
+    TYPE = "package_release_component"
+
+    package = models.ForeignKey(Package, on_delete=models.CASCADE)
+    release_component = models.ForeignKey(ReleaseComponent, on_delete=models.CASCADE)
+
+    class Meta:
+        default_related_name = "%(app_label)s_%(model_name)s"
+        unique_together = (("package", "release_component"),)


### PR DESCRIPTION
[noissue]

This just splits up one python source file into three, without changing anything.
I think splitting up the content models in this way makes things clearer going forward, especially if we end up massively refactoring the existing `Release` content type.