### PR TITLE
Make more dependencies explicit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+# All things django and asyncio are deliberately left to pulpcore
+# Example transitive requirements: asgiref, asyncio, aiohttp
 pulpcore>=3.21.0.dev,<3.25
 python-debian>=0.1.44,<0.2.0
+python-gnupg>=0.4.9,<0.6
+jsonschema>=4.6,<5.0


### PR DESCRIPTION
[noissue]

Note that I have no intention of making any django or drf dependencies
explicit. I want those to be handled by pulpcore. If pulpcore decides to
throw something out, I *want* things to break, so I am forced to fix
them for the next release.

Other candidates for handling via pulpcore: asgiref, asyncio, aiohttp