### PR TITLE
Provide documentation for the pulp-cli plugin

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,10 @@ If you are just getting started with the plugin, read the high level :ref:`featu
 See :ref:`workflows <workflows>` for detailed usage examples.
 See the :ref:`REST API <rest_api>` documentation for an exhaustive feature reference.
 
+The examples in this documentation show examples in two formats: the `httpie` HTTP queries you would make to call the 
+REST API itself, and (where implemented) a corresponding `pulp_cli_deb` pulp CLI equivalent. To read more about the
+`pulp_cli_deb` command line plugin, read :ref:`pulp CLI plugin <pulp_cli_deb>`.
+
 The most important places relating to this project:
 
 * The `Pulp project`_ homepage.
@@ -28,6 +32,7 @@ Table of Contents
    :maxdepth: 1
 
    installation
+   pulp_cli_deb
    feature_overview
    workflows
    rest_api

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,3 +13,5 @@ This will both work for entirely new Pulp installations, as well as to add the `
 
 If you need more help with advanced installation scenarios you can either consult the documentation referenced above, or else join the ``pulp`` Matrix/IRC channel for interactive help.
 See the `Pulp project help page`_ for more information and additional ways on how to get in contact with the Pulp community.
+
+It is useful to note that there is a pulp CLI plugin for ``pulp_deb``, which is documented at :ref:`pulp CLI plugin <pulp_cli_deb>`.

--- a/docs/pulp_cli_deb.rst
+++ b/docs/pulp_cli_deb.rst
@@ -1,0 +1,37 @@
+.. _pulp_cli_deb:
+
+Pulp CLI plugin
+================================================================================
+
+Many of the examples in this documentation are based on the `httpie` command.
+However, there is also a work-in-progress plugin for the `pulp-cli` command
+line tool available.
+
+To install the command line plugin, simply `pip install` it into the python
+environment that your `pulp-cli` is installed into. This is most likely the
+system pip if you have used the `pulp-installer` ansible based installation
+method. In that case, you can install the CLI plugin like this:
+
+.. code-block:: bash
+
+    sudo pip3 install pulp_cli_deb
+
+You can test if the plugin is installed by requesting help from pulp-cli, like
+this:
+
+.. code-block:: bash
+
+    # pulp deb --help
+    Usage: pulp deb [OPTIONS] COMMAND [ARGS]...
+
+    Options:
+    --help  Show this message and exit.
+
+    Commands:
+    distribution
+    publication
+    remote
+    repository
+
+We have endevoured to provide examples of using these commands where relevant in
+the :ref:`workflows <workflows>` documentation.

--- a/docs/workflows/publish.rst
+++ b/docs/workflows/publish.rst
@@ -98,6 +98,12 @@ This returns the path of the created publication:
 
    http get $BASE_ADDR/pulp/api/v3/tasks/d49e056f-a637-454a-8797-67f81648b60f/ | jq '.created_resources[0]'
 
+Similarly, you can create your publication using :ref:`pulp CLI plugin <pulp_cli_deb>`:
+
+.. code-block:: bash
+
+   pulp deb publication create --repository nginx --simple True
+
 
 Create a Distribution
 --------------------------------------------------------------------------------
@@ -214,3 +220,10 @@ An example apt source file could be like,
 .. code-block:: ini
 
    deb [trusted=yes arch=amd64 ] http://pulp3-source-debian10.hostname.example.com/pulp/content/nginx/ default  all
+
+Similarly, you can create your distribution using :ref:`pulp CLI plugin <pulp_cli_deb>`:
+
+.. code-block:: bash
+
+   pulp deb distribution create --name nginx --base-path nginx \
+      --publication "/pulp/api/v3/publications/deb/apt/fd43ed03-b477-4daf-859d-e0d8419a458b/"

--- a/docs/workflows/sync.rst
+++ b/docs/workflows/sync.rst
@@ -35,6 +35,13 @@ This will return a ``201 Created`` response:
        "versions_href": "/pulp/api/v3/repositories/deb/apt/1c8734dd-d4cb-4c2f-811a-87235f786444/versions/"
    }
 
+Or alternatively with the :ref:`pulp CLI plugin <pulp_cli_deb>`:
+
+. code-block:: bash
+
+   pulp deb repository create --name "nginx" --description "nginx package repository"
+
+This will output an identical JSON block to the HTTP post example.
 
 Create a Remote
 --------------------------------------------------------------------------------
@@ -83,6 +90,14 @@ This will return a ``201 Created`` response:
    This breaks synchronization from partial mirrors, and can be overriden by setting `ignore_missing_package_indices=True` on the remote.
    Alternatively, use FORCE_IGNORE_MISSING_PACKAGE_INDICES=True in your Pulp configuration file, to force this behaviour for all remotes.
 
+Or alternatively with the :ref:`pulp CLI plugin <pulp_cli_deb>`:
+
+. code-block:: bash
+
+   pulp deb remote create --name "nginx.org" --url "http://nginx.org/packages/debian" \
+       --distribution "buster"
+
+This will output an identical JSON block to the HTTP post example.
 
 Sync Repository with Remote
 --------------------------------------------------------------------------------
@@ -180,3 +195,7 @@ Notice that when the synchronize task completes, it creates a new version, which
     Learn more about scheduling tasks `here <https://docs.pulpproject.org/pulpcore/workflows/scheduling-tasks.html>`_.
 
 Continue with :doc:`publish` to make your synced repository consumable.
+
+.. note::
+
+    There is currently no :ref:`pulp CLI plugin <pulp_cli_deb>` equivalent for this operation.


### PR DESCRIPTION
It would be nice to not have to make raw HTTP calls to manage repositories. This PR at the moment is just a minimal implementation of creating a repository, but I wanted to ask how you'd feel about a CLI plugin.