### PR TITLE
Handle duplicate "default" distribution publications

### DIFF
--- a/CHANGES/601.bugfix
+++ b/CHANGES/601.bugfix
@@ -1,0 +1,1 @@
+Added handling for the special case when publishing an upstream repo containing a distribution named "default" using both simple and structured publish modes.

--- a/pulp_deb/app/tasks/publishing.py
+++ b/pulp_deb/app/tasks/publishing.py
@@ -136,6 +136,13 @@ def publish(repository_version_pk, simple=False, structured=False, signing_servi
                 for release in Release.objects.filter(
                     pk__in=repo_version.content.order_by("-pulp_created"),
                 ):
+                    if simple and release.distribution == "default":
+                        message = (
+                            'Ignoring structured "default" distribution for publication that also '
+                            "uses simple mode."
+                        )
+                        log.warning(_(message))
+                        continue
                     architectures = ReleaseArchitecture.objects.filter(
                         pk__in=repo_version.content.order_by("-pulp_created"),
                         release=release,


### PR DESCRIPTION
closes #601

This occurs when an upstream repo contains a distribution named
"default" and we then try to publish using both "simple=True" and
"structured=True".