### PR TITLE
Do not validate_duplicate_content for APT repositories

### DIFF
--- a/CHANGES/632.bugfix
+++ b/CHANGES/632.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug preventing the synchronization of repos referencing a single package from multiple package indices.

--- a/pulp_deb/app/models/repository.py
+++ b/pulp_deb/app/models/repository.py
@@ -1,6 +1,6 @@
 from pulpcore.plugin.models import Repository
 
-from pulpcore.plugin.repo_version_utils import remove_duplicates, validate_repo_version
+from pulpcore.plugin.repo_version_utils import remove_duplicates, validate_version_paths
 
 from pulp_deb.app.models import (
     AptRemote,
@@ -67,7 +67,7 @@ class AptRepository(Repository):
         from pulp_deb.app.tasks.exceptions import DuplicateDistributionException
 
         remove_duplicates(new_version)
-        validate_repo_version(new_version)
+        validate_version_paths(new_version)
         releases = new_version.get_content(Release.objects.all())
         distributions = []
         for release in releases:


### PR DESCRIPTION
closes #632

Using validate_duplicate_content prevents successfull synchronization
when multiple package indices contain references to the same package.
However, this is an entirely legitimate situation for separate
distributions/releases within a single APT repo. Further more, the so
created duplicate package content, does not cause any adverse effects,
since it is actually identical and only one of each duplicate will be
saved.

Note that this issue was masked prior to the introduction of the
optimize sync feature, since we were inadvertently using the Repository
class from pulpcore instead of the AptRepository class from pulp_deb.