### PR TITLE
Add release and release_component filters to package list api

### DIFF
--- a/pulp_deb/app/viewsets/content.py
+++ b/pulp_deb/app/viewsets/content.py
@@ -1,8 +1,9 @@
 from gettext import gettext as _  # noqa
 
+from django_filters import Filter
 from pulpcore.plugin.viewsets import (
-    ContentViewSet,
     ContentFilter,
+    ContentViewSet,
     SingleArtifactContentUploadViewSet,
 )
 
@@ -36,10 +37,57 @@ class GenericContentViewSet(SingleArtifactContentUploadViewSet):
     filterset_class = GenericContentFilter
 
 
+class PackageToReleaseComponentFilter(Filter):
+    """
+    Filter Packages by a ReleaseComponent.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("help_text", _("(uuid) Filter results where Package in ReleaseComponent"))
+        super().__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        """
+        Args:
+            qs (django.db.models.query.QuerySet): The Content Queryset
+            value (string): The ReleaseComponent uuid to filter by
+        """
+        if value is None:
+            # user didn't supply a value
+            return qs
+
+        return qs.filter(deb_packagereleasecomponent__release_component=value)
+
+
+class PackageToReleaseFilter(Filter):
+    """
+    Filter Packages by a Release.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("help_text", _("(uuid) Filter results where Package in Release"))
+        super().__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        """
+        Args:
+            qs (django.db.models.query.QuerySet): The Content Queryset
+            value (string): The Release uuid to filter by
+        """
+        if value is None:
+            # user didn't supply a value
+            return qs
+
+        return qs.filter(deb_packagereleasecomponent__release_component__release=value)
+
+
 class PackageFilter(ContentFilter):
     """
     FilterSet for Package.
     """
+
+    release_component = PackageToReleaseComponentFilter()
+    release = PackageToReleaseFilter()
 
     class Meta:
         model = models.Package

--- a/pulp_deb/app/viewsets/content.py
+++ b/pulp_deb/app/viewsets/content.py
@@ -48,7 +48,7 @@ class FilterWithHelpMessage(Filter):
         """
         Args:
             qs (django.db.models.query.QuerySet): The Content Queryset
-            value (string): The ReleaseComponent uuid to filter by
+            value (string): The value to filter by
         """
         if value is None:
             # user didn't supply a value


### PR DESCRIPTION
These filters allow you to filter a package list by release or release_component uuid that they are in, and vice versa.

Examples:

```
/pulp/api/v3/content/deb/packages/?release=<release_uuid>
/pulp/api/v3/content/deb/packages/?release_component=<release_component_uuid>
/pulp/api/v3/content/deb/releases/?package=<package_uuid>
/pulp/api/v3/content/deb/release_components/?package=<package_uuid>
```