### PR TITLE
Remove mirror default of True

### DIFF
--- a/pulp_deb/app/viewsets/repository.py
+++ b/pulp_deb/app/viewsets/repository.py
@@ -54,7 +54,7 @@ class AptRepositoryViewSet(RepositoryViewSet, ModifyRepositoryActionMixin):
         # Validate synchronously to return 400 errors.
         serializer.is_valid(raise_exception=True)
         remote = serializer.validated_data.get("remote", repository.remote)
-        mirror = serializer.validated_data.get("mirror", True)
+        mirror = serializer.validated_data.get("mirror")
         optimize = serializer.validated_data.get("optimize")
 
         result = dispatch(


### PR DESCRIPTION
The `mirror` field defaults to False in the RepositorySyncURLSerializer:

https://github.com/pulp/pulpcore/blob/ab7f4b7c7e1939ae605a8d7cf996c6498c83ddd7/pulpcore/app/serializers/repository.py#L336

So it should always be set and it should be False by default. This line however gives the impression that mirror is True by default so update it so it no longer has a default. This shouldn't impact users.

[noissue]