### PR TITLE
#682: Sign the metadata for all releases in a repo concurrently, greatly speeding up the publish task in environments where signing is slow.

### DIFF
--- a/CHANGES/682.feature
+++ b/CHANGES/682.feature
@@ -1,0 +1,1 @@
+Sign the metadata for all releases in a repo concurrently, greatly speeding up the publish task in environments where signing is slow.


### PR DESCRIPTION
This PR breaks `_ReleaseHelper.finish()` up into three parts, `save_unsigned_metadata`, `sign_metadata`, and `save_signed_metdata`, and then calls `sign_metadata` concurrently for all releases at once.

There are potentially many other ways to accomplish the same thing, but this seemed the simplest to me. We don't have to worry about thread management or locking. The database driver doesn't have to be async compatible. An the overall semantics of the Task remain the same, it will still block the worker until it's done, it just happens much faster in environments with slow signing.

Even in `asyncio` there are other ways this could be accomplished. We could for example use `asyncio.Tasks` and `asyncio.wait`. The benefit of `asyncio.gather` is simplicity, and it also offers by default behavior of halting immediately upon an Exception and passing it up the synchronous stack, which is behavior you have to program in explicitly if you're using `Tasks`/`wait`.