### PR TITLE
Add removal warning about changed upload API behaviour

### DIFF
--- a/CHANGES/592.removal
+++ b/CHANGES/592.removal
@@ -1,0 +1,2 @@
+Package and generic content API endpoints no longer return errors when entities already exist.
+Instead they return the existing entities as if they had just been created.


### PR DESCRIPTION
[noissue]

This is an addition to the as of yet unreleased issue #592

This PR has resulted from this discussion: https://discourse.pulpproject.org/t/unable-to-upload-packages-to-rpm-repo-if-allready-stored-in-pulp/841

Note that the new behaviour is currently only for generic and the various package content, but not for metadata/upstream metadata content. This could be pretty confusing for people. Maybe we should have the new behavior for all content API endpoints? (The reason we did things the way we did, is because we set out to simplify the package upload workflow).