### PR TITLE
Fixed KeyError during publish for unmatched arch

### DIFF
--- a/CHANGES/777.bugfix
+++ b/CHANGES/777.bugfix
@@ -1,0 +1,2 @@
+Fixed KeyError during publish if package has architecture that's not supported in the Packages file.
+Instead, a warning message will be logged.

--- a/pulp_deb/app/tasks/publishing.py
+++ b/pulp_deb/app/tasks/publishing.py
@@ -245,10 +245,19 @@ class _ComponentHelper:
             )
             published_artifact.save()
         package_serializer = Package822Serializer(package, context={"request": None})
-        package_serializer.to822(self.component).dump(
-            self.package_index_files[package.architecture][0]
-        )
-        self.package_index_files[package.architecture][0].write(b"\n")
+
+        try:
+            package_serializer.to822(self.component).dump(
+                self.package_index_files[package.architecture][0]
+            )
+        except KeyError:
+            log.warn(
+                f"Published package '{package.relative_path}' with architecture "
+                f"'{package.architecture}' was not added to component '{self.component}' in "
+                f"distribution '{self.parent.distribution}' because it lacks this architecture!"
+            )
+        else:
+            self.package_index_files[package.architecture][0].write(b"\n")
 
     def finish(self):
         # Publish Packages files


### PR DESCRIPTION
When publishing a package that doesn't have a matching architecture in the release component, a KeyError gets thrown. This fixes it so that a warning message is instead logged.

One option would have been to fail the publish with a more user friendly error. However, in our use case, repos are shared across different users/teams so if one team adds a package with an unsupported arch, no one can publish the repo (which is bad). 

In the future, I think it would be good to add some validation to the repo modify endpoint to prevent packages with unsupported architectures from being added to repos.