### PR TITLE
Add tests for related content filters

### DIFF
--- a/CHANGES/780.misc
+++ b/CHANGES/780.misc
@@ -1,0 +1,1 @@
+Add tests for content filters, and make filters return empty list if Content not in RepoVersion instead of raising ValidationError.

--- a/pulp_deb/app/viewsets/content.py
+++ b/pulp_deb/app/viewsets/content.py
@@ -130,9 +130,8 @@ class ContentRelationshipFilter(Filter):
 
         arg_instance = NamedModelViewSet.get_resource(arg_href, self.ARG_CLASS)
         if not repo_version.content.filter(pk=arg_instance.pk).exists():
-            raise ValidationError(
-                detail=_("Specified filter argument is not in specified RepositoryVersion")
-            )
+            # If the package (or whatever) is not in the repo version then return an empty list.
+            return qs.none()
 
         return self._filter(qs, arg_instance, repo_version.content)
 

--- a/pulp_deb/tests/functional/conftest.py
+++ b/pulp_deb/tests/functional/conftest.py
@@ -14,6 +14,8 @@ from pulpcore.client.pulp_deb import (
     AptRepositorySyncURL,
     ContentGenericContentsApi,
     ContentPackagesApi,
+    ContentReleasesApi,
+    ContentReleaseComponentsApi,
     DebAptPublication,
     DebVerbatimPublication,
     DistributionsAptApi,
@@ -66,6 +68,18 @@ def apt_distribution_api(apt_client):
 def apt_package_api(apt_client):
     """Fixture for APT package API."""
     return ContentPackagesApi(apt_client)
+
+
+@pytest.fixture
+def apt_release_api(apt_client):
+    """Fixture for APT release API."""
+    return ContentReleasesApi(apt_client)
+
+
+@pytest.fixture
+def apt_release_component_api(apt_client):
+    """Fixture for APT release API."""
+    return ContentReleaseComponentsApi(apt_client)
 
 
 @pytest.fixture


### PR DESCRIPTION
And make filters return empty list if content not in RepoVersion instead of raising a ValidationError, which I believe to be more correct behavior.

closes #780