### PR TITLE
Fix content creation when unapplying migration 0021

### DIFF
--- a/CHANGES/806.bugfix
+++ b/CHANGES/806.bugfix
@@ -1,0 +1,1 @@
+Fixed content creating code triggered in rare edge cases when unapplying DB migration 0021.

--- a/pulp_deb/app/migrations/0021_remove_release_from_structure_types.py
+++ b/pulp_deb/app/migrations/0021_remove_release_from_structure_types.py
@@ -53,12 +53,12 @@ def reassociate_with_release_for_model(release_model, model_to_associate):
             )
         except release_model.DoesNotExist:
             # We do not batch for this rare edge case!
-            release = Release(
+            release = Release.objects.create(
+                pulp_type='deb.release',
                 codename=content.codename,
                 distribution=content.distribution,
                 suite=content.suite,
             )
-            release.save()
 
         content.release = release
         content_to_update.append(content)


### PR DESCRIPTION
[noissue]

The previous version cannot work, but no one noticed, since it is not released yet, and is only designed to catch a rare edge case when unapplying the migration 0021.