### PR TITLE
Fix an edge case where some databases fail to migrate to 3.0.0 with a unique constraint error.

### DIFF
--- a/CHANGES/923.bugfix
+++ b/CHANGES/923.bugfix
@@ -1,0 +1,1 @@
+Fix an edge case where some databases fail to migrate to 3.0.0 with a unique constraint error.

--- a/pulp_deb/app/migrations/0021_remove_release_from_structure_types.py
+++ b/pulp_deb/app/migrations/0021_remove_release_from_structure_types.py
@@ -78,6 +78,15 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # Turn off the unique constraints temporarily, they will get re-created in migration 0025
+        migrations.AlterUniqueTogether(
+            name='releasearchitecture',
+            unique_together=set(),
+        ),
+        migrations.AlterUniqueTogether(
+            name='releasecomponent',
+            unique_together=set(),
+        ),
         migrations.AddField(
             model_name='releasearchitecture',
             name='codename',
@@ -118,14 +127,6 @@ class Migration(migrations.Migration):
         migrations.RunSQL(
             sql="SET CONSTRAINTS ALL IMMEDIATE;",
             reverse_sql="",
-        ),
-        migrations.AlterUniqueTogether(
-            name='releasearchitecture',
-            unique_together={('architecture', 'distribution', 'codename', 'suite')},
-        ),
-        migrations.AlterUniqueTogether(
-            name='releasecomponent',
-            unique_together={('distribution', 'component', 'codename', 'suite')},
         ),
         migrations.AlterField(
             model_name='releasearchitecture',


### PR DESCRIPTION
See the bug report for more discussion and a stack trace.

Closes #923