### PR TITLE
Add extra filters linking SourcePackages to Releases and ReleaseComponents

### DIFF
--- a/CHANGES/926.feature
+++ b/CHANGES/926.feature
@@ -1,0 +1,1 @@
+Added extra filters linking SourcePackages to Releases and ReleaseComponents.

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -1190,13 +1190,13 @@ class SourcePackageReleaseComponentSerializer(NoArtifactContentSerializer):
         help_text="Source package that is contained in release_component.",
         many=False,
         queryset=SourcePackage.objects.all(),
-        view_name="deb-souce_package_component-detail",
+        view_name="content-deb/source_packages-detail",
     )
     release_component = DetailRelatedField(
         help_text="ReleaseComponent this source package is contained in.",
         many=False,
         queryset=ReleaseComponent.objects.all(),
-        view_name="deb-release_component-detail",
+        view_name="content-deb/release_components-detail",
     )
 
     class Meta(NoArtifactContentSerializer.Meta):

--- a/pulp_deb/app/viewsets/content.py
+++ b/pulp_deb/app/viewsets/content.py
@@ -519,10 +519,37 @@ class PackageReleaseComponentViewSet(ContentViewSet):
     filterset_class = PackageReleaseComponentFilter
 
 
+class SourcePackageToReleaseComponentFilter(ContentRelationshipFilter):
+    HELP = "Filter results where SourcePackage in ReleaseComponent"
+    ARG = "release_component_href"
+    ARG_CLASS = models.ReleaseComponent
+
+    def _filter(self, qs, arg, rv_content):
+        sprc_qs = models.SourcePackageReleaseComponent.objects.filter(
+            pk__in=rv_content, release_component=arg.pk
+        )
+        return qs.filter(deb_sourcepackagereleasecomponent__in=sprc_qs)
+
+
+class SourcePackageToReleaseFilter(ContentRelationshipFilter):
+    HELP = "Filter results where SourcePackage in Release"
+    ARG = "release_href"
+    ARG_CLASS = models.Release
+
+    def _filter(self, qs, arg, rv_content):
+        sprc_qs = models.SourcePackageReleaseComponent.objects.filter(
+            pk__in=rv_content, release_component__distribution=arg.distribution
+        )
+        return qs.filter(deb_sourcepackagereleasecomponent__in=sprc_qs)
+
+
 class SourcePackageFilter(ContentFilter):
     """
     FilterSet for Debian Source Packages.
     """
+
+    release_component = SourcePackageToReleaseComponentFilter()
+    release = SourcePackageToReleaseFilter()
 
     class Meta:
         model = models.SourcePackage
@@ -535,6 +562,7 @@ class SourcePackageFilter(ContentFilter):
             "maintainer",
             "uploaders",
             "homepage",
+            "relative_path",
             "vcs_browser",
             "vcs_arch",
             "vcs_bzr",


### PR DESCRIPTION
closes #926

I'm also changing the `view_name` of the fields in `SourcePackageReleaseComponentSerializer`, which _might_ be fixing a bug? But if it is it's fixing an unreleased bug, so whatever. But I could not get creating a new `SourcePackageReleaseComponent` object over the API to work properly without this, instead it would would return a `Invalid hyperlink - No URL match.` error for each field.