### PR TITLE
Ignore release version and description if null

### DIFF
--- a/CHANGES/959.bugfix
+++ b/CHANGES/959.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where publish failed if release ``version`` or ``description`` fields are null.

--- a/pulp_deb/app/tasks/publishing.py
+++ b/pulp_deb/app/tasks/publishing.py
@@ -415,7 +415,7 @@ class _ReleaseHelper:
             self.release["Label"] = release.label
         if release.suite:
             self.release["Suite"] = release.suite
-        if release.version != NULL_VALUE:
+        if release.version and release.version != NULL_VALUE:
             self.release["Version"] = release.version
         if not release.codename:
             release.codename = distribution.split("/")[0] if distribution != "/" else "flat-repo"
@@ -423,7 +423,7 @@ class _ReleaseHelper:
         self.release["Date"] = datetime.now(tz=timezone.utc).strftime("%a, %d %b %Y %H:%M:%S %z")
         self.release["Architectures"] = " ".join(architectures)
         self.release["Components"] = ""  # Will be set later
-        if release.description != NULL_VALUE:
+        if release.description and release.description != NULL_VALUE:
             self.release["Description"] = release.description
         self.release["Acquire-By-Hash"] = "yes" if APT_BY_HASH else "no"
 


### PR DESCRIPTION
Passing release version or description to python-deb fails if the fields are None.

fixes #959