### PR TITLE
Set SERVE_FROM_PUBLICATION on AptDistribution

### DIFF
--- a/CHANGES/976.bugfix
+++ b/CHANGES/976.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where pulp_deb was serving unpublished content when distributing a repository that has content but no publications.

--- a/pulp_deb/app/models/publication.py
+++ b/pulp_deb/app/models/publication.py
@@ -46,6 +46,7 @@ class AptDistribution(Distribution):
     """
 
     TYPE = "apt-distribution"
+    SERVE_FROM_PUBLICATION = True
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"


### PR DESCRIPTION
This prevents the content app from serving unpublished content when a repo is set on a distribution:

https://github.com/pulp/pulpcore/commit/27a0dc7424769b2d5d7e98ebc4cf9cdba6cdc149

Also, this setting will be used to protect repo versions once the repo version protection work is merged:

https://github.com/pulp/pulpcore/pull/4750

fixes #976