### PR TITLE
Fix black errors

### DIFF
--- a/.ci/scripts/collect_changes.py
+++ b/.ci/scripts/collect_changes.py
@@ -19,9 +19,11 @@ tc_settings = toml.load("pyproject.toml")["tool"]["towncrier"]
 CHANGELOG_FILE = tc_settings.get("filename", "NEWS.rst")
 START_STRING = tc_settings.get(
     "start_string",
-    "<!-- towncrier release notes start -->\n"
-    if CHANGELOG_FILE.endswith(".md")
-    else ".. towncrier release notes start\n",
+    (
+        "<!-- towncrier release notes start -->\n"
+        if CHANGELOG_FILE.endswith(".md")
+        else ".. towncrier release notes start\n"
+    ),
 )
 TITLE_FORMAT = tc_settings.get("title_format", "{name} {version} ({project_date})")
 

--- a/.ci/scripts/schema.py
+++ b/.ci/scripts/schema.py
@@ -7,6 +7,7 @@ https://spec.openapis.org/oas/v3.0.3#patterned-fields
 But some pulp paths start with curly brackets e.g. {artifact_href}
 This script modifies drf-spectacular schema validation to accept slashes and curly brackets.
 """
+
 import json
 from drf_spectacular.validation import JSON_SCHEMA_SPEC_PATH
 

--- a/pulp_deb/app/models/content/content.py
+++ b/pulp_deb/app/models/content/content.py
@@ -6,6 +6,7 @@ obvious example would be a model to represent .deb packages, but other examples 
 like language and Debian installer files. Not included are models for metadata files like Release
 files or APT repository package indices.
 """
+
 import os
 
 from django.db import models

--- a/pulp_deb/app/models/content/structure_content.py
+++ b/pulp_deb/app/models/content/structure_content.py
@@ -10,6 +10,7 @@ IMPORTANT: It is essential that these models don't contain anything that isn't s
 information. This ensures, that copying structure content between different Pulp repositories, does
 not inadvertantly copy anything that is not structure relevant.
 """
+
 import os
 
 from django.db import models

--- a/pulp_deb/app/models/content/verbatim_metadata.py
+++ b/pulp_deb/app/models/content/verbatim_metadata.py
@@ -4,6 +4,7 @@ This module contains Pulp content models that are used to represent APT reposito
 (down to the checksum) as it was synced from some upstream APT repostiroy. These metadata types are
 exclusively used for verbatim publications.
 """
+
 from django.db import models
 
 from pulpcore.plugin.models import Content

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -1139,9 +1139,9 @@ class SourcePackageSerializer(MultipleArtifactContentSerializer):
                         " and sha256 '{sha256}'."
                     ).format(name=source["name"], sha256=source["sha256"])
                 )
-            artifacts[
-                os.path.join(os.path.dirname(data["relative_path"]), source["name"])
-            ] = content.first()
+            artifacts[os.path.join(os.path.dirname(data["relative_path"]), source["name"])] = (
+                content.first()
+            )
 
         data["artifacts"] = artifacts
         return data

--- a/pulp_deb/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_deb/tests/functional/api/test_crud_content_unit.py
@@ -1,4 +1,5 @@
 """Tests that perform actions over content unit."""
+
 from uuid import uuid4
 import pytest
 

--- a/pulp_deb/tests/functional/api/test_crud_packages.py
+++ b/pulp_deb/tests/functional/api/test_crud_packages.py
@@ -1,4 +1,5 @@
 """Tests that perform actions over packages."""
+
 from uuid import uuid4
 import pytest
 

--- a/pulp_deb/tests/functional/api/test_crud_remotes.py
+++ b/pulp_deb/tests/functional/api/test_crud_remotes.py
@@ -1,4 +1,5 @@
 """Tests that CRUD deb remotes."""
+
 from random import choice
 from uuid import uuid4
 import pytest

--- a/pulp_deb/tests/functional/api/test_download_content.py
+++ b/pulp_deb/tests/functional/api/test_download_content.py
@@ -1,4 +1,5 @@
 """Tests that verify download of content served by Pulp."""
+
 import os
 import pytest
 import hashlib

--- a/pulp_deb/tests/functional/api/test_download_policies.py
+++ b/pulp_deb/tests/functional/api/test_download_policies.py
@@ -1,4 +1,5 @@
 """Tests for Pulp download policies."""
+
 import pytest
 
 from pulp_deb.tests.functional.constants import DEB_FIXTURE_PACKAGE_COUNT, DEB_FIXTURE_SUMMARY

--- a/pulp_deb/tests/functional/api/test_duplicate_packages.py
+++ b/pulp_deb/tests/functional/api/test_duplicate_packages.py
@@ -8,6 +8,7 @@ contain identical packages, but may not contain any duplicates.
 To ensure this is the case we use the handle_duplicate_packages function. As such, these tests are
 primarily intended to test this function.
 """
+
 import pytest
 from uuid import uuid4
 

--- a/pulp_deb/tests/functional/api/test_publish.py
+++ b/pulp_deb/tests/functional/api/test_publish.py
@@ -497,7 +497,7 @@ def parse_package_index(pkg_idx):
     """
     packages = {}
     for package in deb822.Packages.iter_paragraphs(pkg_idx):
-        packages[
-            "-".join([package["Package"], package["Version"], package["Architecture"]])
-        ] = package
+        packages["-".join([package["Package"], package["Version"], package["Architecture"]])] = (
+            package
+        )
     return packages

--- a/pulp_deb/tests/functional/api/test_pulp_to_pulp.py
+++ b/pulp_deb/tests/functional/api/test_pulp_to_pulp.py
@@ -1,4 +1,5 @@
 """Tests that verify download of content served by Pulp."""
+
 import pytest
 
 from pulp_deb.tests.functional.constants import (

--- a/pulp_deb/tests/functional/api/test_pulpexport_pulpimport.py
+++ b/pulp_deb/tests/functional/api/test_pulpexport_pulpimport.py
@@ -4,6 +4,7 @@ Tests PulpImporter/PulpExporter and PulpImport/PulpExport functionality.
 NOTE: assumes ALLOWED_EXPORT_PATHS and ALLOWED_IMPORT_PATHS settings contain "/tmp"
 all tests will fail if that is not the case.
 """
+
 import pytest
 
 from uuid import uuid4

--- a/pulp_deb/tests/functional/api/test_sync.py
+++ b/pulp_deb/tests/functional/api/test_sync.py
@@ -1,4 +1,5 @@
 """Tests that sync deb repositories in optimized mode."""
+
 import pytest
 
 from pulpcore.tests.functional.utils import PulpTaskError

--- a/pulp_deb/tests/performance/test_publish.py
+++ b/pulp_deb/tests/performance/test_publish.py
@@ -1,4 +1,5 @@
 """Tests that publish deb plugin repositories."""
+
 import pytest
 
 from pulp_deb.tests.functional.constants import (

--- a/pulp_deb/tests/performance/test_pulp_to_pulp.py
+++ b/pulp_deb/tests/performance/test_pulp_to_pulp.py
@@ -1,4 +1,5 @@
 """Tests that verify download of deb content served by Pulp."""
+
 import pytest
 
 from pulp_deb.tests.functional.utils import get_counts_from_content_summary

--- a/pulp_deb/tests/performance/test_sync.py
+++ b/pulp_deb/tests/performance/test_sync.py
@@ -1,4 +1,5 @@
 """Tests that sync deb plugin repositories."""
+
 import pytest
 
 from pulp_deb.tests.functional.constants import (


### PR DESCRIPTION
A new version of black was released today (24.1.0) and it looks like it changed some formatting. pulp_deb doesn't pin black so the CI lint tests are failing. Here, I upgraded my local version of black and ran it to reformat the code.