### PR TITLE
Suppress the warnings about python3-apt not being installed

### DIFF
--- a/CHANGES/1019.bugfix
+++ b/CHANGES/1019.bugfix
@@ -1,0 +1,1 @@
+Suppressed deb822's confusing log warning about python-apt not being installed.

--- a/pulp_deb/app/tasks/synchronizing.py
+++ b/pulp_deb/app/tasks/synchronizing.py
@@ -932,7 +932,9 @@ class DebFirstStage(Stage):
         # parse package_index
         package_futures = []
         package_index_artifact = await _get_main_artifact_blocking(package_index)
-        for package_paragraph in deb822.Packages.iter_paragraphs(package_index_artifact.file):
+        for package_paragraph in deb822.Packages.iter_paragraphs(
+            package_index_artifact.file, use_apt_pkg=False
+        ):
             # Sanity check the architecture from the package paragraph:
             package_paragraph_architecture = package_paragraph["Architecture"]
             if release_file.distribution[-1] == "/":
@@ -1108,7 +1110,9 @@ class DebFirstStage(Stage):
         # parse source_index
         source_package_content_futures = []
         source_index_artifact = await _get_main_artifact_blocking(source_index)
-        for source_paragraph in deb822.Sources.iter_paragraphs(source_index_artifact.file):
+        for source_paragraph in deb822.Sources.iter_paragraphs(
+            source_index_artifact.file, use_apt_pkg=False
+        ):
             try:
                 source_dir = source_paragraph["Directory"]
                 source_relpath = os.path.join(source_dir, "blah")

--- a/pulp_deb/tests/functional/api/test_publish.py
+++ b/pulp_deb/tests/functional/api/test_publish.py
@@ -496,7 +496,7 @@ def parse_package_index(pkg_idx):
     Returns a dict of the packages by '<Package>-<Version>-<Architecture>'.
     """
     packages = {}
-    for package in deb822.Packages.iter_paragraphs(pkg_idx):
+    for package in deb822.Packages.iter_paragraphs(pkg_idx, use_apt_pkg=False):
         packages[
             "-".join([package["Package"], package["Version"], package["Architecture"]])
         ] = package


### PR DESCRIPTION
closes #1019

We no longer want to see warnings like the following in the log:

pulpcore-worker: /usr/lib/python3.9/site-packages/debian/deb822.py:716: UserWarning: Parsing of Deb822 data with python3-apt’s apt_pkg was requested but this package is not importable. Is python3-apt installed?