### PR TITLE
[PR #1020/98d82667 backport][3.0] Suppress the warnings about python3-apt not being installed

### DIFF
--- a/CHANGES/1019.bugfix
+++ b/CHANGES/1019.bugfix
@@ -1,0 +1,1 @@
+Suppressed deb822's confusing log warning about python-apt not being installed.

--- a/pulp_deb/app/tasks/synchronizing.py
+++ b/pulp_deb/app/tasks/synchronizing.py
@@ -923,7 +923,9 @@ class DebFirstStage(Stage):
         # parse package_index
         package_futures = []
         package_index_artifact = await _get_main_artifact_blocking(package_index)
-        for package_paragraph in deb822.Packages.iter_paragraphs(package_index_artifact.file):
+        for package_paragraph in deb822.Packages.iter_paragraphs(
+            package_index_artifact.file, use_apt_pkg=False
+        ):
             # Sanity check the architecture from the package paragraph:
             package_paragraph_architecture = package_paragraph["Architecture"]
             if release_file.distribution[-1] == "/":

--- a/pulp_deb/tests/functional/api/test_publish.py
+++ b/pulp_deb/tests/functional/api/test_publish.py
@@ -496,7 +496,7 @@ def parse_package_index(pkg_idx):
     Returns a dict of the packages by '<Package>-<Version>-<Architecture>'.
     """
     packages = {}
-    for package in deb822.Packages.iter_paragraphs(pkg_idx):
+    for package in deb822.Packages.iter_paragraphs(pkg_idx, use_apt_pkg=False):
         packages[
             "-".join([package["Package"], package["Version"], package["Architecture"]])
         ] = package


### PR DESCRIPTION
(cherry picked from commit 98d826674f203317e615c3568ff67f2ceb82c6c4)