### PR TITLE
Fix source package publish error

### DIFF
--- a/CHANGES/1053.bugfix
+++ b/CHANGES/1053.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug where an ``IntegrityError`` was raised during publish when a source package belonged to
+two dists.

--- a/pulp_deb/app/tasks/publishing.py
+++ b/pulp_deb/app/tasks/publishing.py
@@ -325,14 +325,15 @@ class _ComponentHelper:
     def add_source_package(self, source_package):
         artifact_set = source_package.contentartifact_set.all()
         for content_artifact in artifact_set:
-            published_artifact = PublishedArtifact(
-                relative_path=source_package.derived_path(
-                    os.path.basename(content_artifact.relative_path), self.component
-                ),
-                publication=self.parent.publication,
-                content_artifact=content_artifact,
-            )
-            published_artifact.save()
+            with suppress(IntegrityError):
+                published_artifact = PublishedArtifact(
+                    relative_path=source_package.derived_path(
+                        os.path.basename(content_artifact.relative_path), self.component
+                    ),
+                    publication=self.parent.publication,
+                    content_artifact=content_artifact,
+                )
+                published_artifact.save()
         dsc_file_822_serializer = DscFile822Serializer(source_package, context={"request": None})
         dsc_file_822_serializer.to822(self.component, paragraph=True).dump(
             self.source_index_file_info[0]

--- a/pulp_deb/tests/functional/api/test_source_package.py
+++ b/pulp_deb/tests/functional/api/test_source_package.py
@@ -1,0 +1,123 @@
+"""Tests related to source packages."""
+
+import json
+import pytest
+import re
+from uuid import uuid4
+
+from pulp_deb.tests.functional.utils import (
+    get_counts_from_content_summary,
+    get_local_package_absolute_path,
+)
+from pulpcore.client.pulpcore.exceptions import ApiException
+
+SOURCE_PACKAGE_RELPATH = "mimir_1.0.dsc"
+SOURCE_PACKAGE_SOURCE = "mimir_1.0.tar.xz"
+SOURCE_PACKAGE_PATH = "data/debian/pool/asgard/m/mimir"
+
+
+def _extract_sha256(body):
+    """Parse the sha256 from the body of an artifact create exception."""
+    error = json.loads(body)["non_field_errors"][0]
+    return re.search("checksum of '([0-9a-fA-F]+)'", error)[1]
+
+
+def _find_existing_artifact(artifacts_api, exc):
+    """Given an exception when creating an artifact, find if there's an existing one."""
+    try:
+        sha256 = _extract_sha256(exc.body)
+        artifact = artifacts_api.list(sha256=sha256).results[0]
+        return artifact
+    except Exception:
+        return None
+
+
+@pytest.fixture
+def artifact_factory(
+    artifacts_api_client,
+    gen_object_with_cleanup,
+):
+    """Factory to create an artifact."""
+
+    def _artifact_factory(relative_name, relative_path=SOURCE_PACKAGE_PATH):
+        try:
+            file = get_local_package_absolute_path(relative_name, relative_path=relative_path)
+            artifact = gen_object_with_cleanup(artifacts_api_client, file)
+        except ApiException as exc:
+            if artifact := _find_existing_artifact(artifacts_api_client, exc):
+                return artifact
+            else:
+                raise
+        return artifact
+
+    return _artifact_factory
+
+
+@pytest.mark.parallel
+def test_upload_source_package_and_publish(
+    artifact_factory,
+    deb_publication_factory,
+    deb_get_repository_by_href,
+    deb_get_content_summary,
+    deb_modify_repository,
+    deb_repository_factory,
+    deb_release_component_factory,
+    deb_source_package_factory,
+    apt_source_package_api,
+    apt_source_release_components_api,
+    deb_source_release_component_factory,
+):
+    """
+    Test uploading a source package and publishing it in two repository releases.
+
+    This tests the fix for https://github.com/pulp/pulp_deb/issues/1053
+    """
+    # Generate a test repo
+    repository = deb_repository_factory()
+    assert repository.latest_version_href.endswith("/0/")
+    repository_href = repository.pulp_href
+
+    # create our source package
+    source_packages = apt_source_package_api.list(relative_path=SOURCE_PACKAGE_RELPATH)
+    if source_packages.count > 0:
+        # source package exists, use it
+        source_package = source_packages.results[0]
+    else:
+        # source package doesn't exist
+        artifact_factory(SOURCE_PACKAGE_SOURCE)
+        artifact = artifact_factory(SOURCE_PACKAGE_RELPATH)
+
+        # Upload a test  source package
+        package_upload_params = {
+            "artifact": artifact.pulp_href,
+            "relative_path": SOURCE_PACKAGE_RELPATH,
+        }
+        source_package = deb_source_package_factory(**package_upload_params)
+    deb_modify_repository(repository, {"add_content_units": [source_package.pulp_href]})
+
+    # create two release components and source release components
+    for _ in range(2):
+        release_component = deb_release_component_factory(
+            repository=repository.pulp_href,
+            distribution=str(uuid4()),
+            component="main",
+        )
+        deb_source_release_component_factory(
+            repository=repository.pulp_href,
+            source_package=source_package.pulp_href,
+            release_component=release_component.pulp_href,
+        )
+
+    # confirm our repository has two source package release components
+    repository = deb_get_repository_by_href(repository_href)
+    assert repository.latest_version_href.endswith("/5/")
+    content_counts = get_counts_from_content_summary(deb_get_content_summary(repository).present)
+    assert content_counts == {
+        "deb.source_package": 1,
+        "deb.source_package_release_component": 2,
+        "deb.release_component": 2,
+    }
+
+    # attempt to publish the repo
+    publication = deb_publication_factory(repository, structured=True)
+    assert publication.repository_version == repository.latest_version_href

--- a/pulp_deb/tests/functional/conftest.py
+++ b/pulp_deb/tests/functional/conftest.py
@@ -16,11 +16,14 @@ from pulpcore.client.pulp_deb import (
     ContentReleaseArchitecturesApi,
     ContentReleaseComponentsApi,
     ContentReleaseFilesApi,
+    ContentSourcePackagesApi,
+    ContentSourceReleaseComponentsApi,
     Copy,
     DebAptPublication,
     DebCopyApi,
     DebReleaseArchitecture,
     DebReleaseComponent,
+    DebSourcePackageReleaseComponent,
     DebVerbatimPublication,
     PublicationsVerbatimApi,
 )
@@ -44,6 +47,12 @@ def apt_package_release_components_api(apt_client):
 
 
 @pytest.fixture(scope="session")
+def apt_source_release_components_api(apt_client):
+    """Fixture for APT source package release components API."""
+    return ContentSourceReleaseComponentsApi(apt_client)
+
+
+@pytest.fixture(scope="session")
 def apt_verbatim_publication_api(apt_client):
     """Fixture for Verbatim publication API."""
     return PublicationsVerbatimApi(apt_client)
@@ -59,6 +68,12 @@ def apt_copy_api(apt_client):
 def apt_package_api(apt_client):
     """Fixture for APT package API."""
     return ContentPackagesApi(apt_client)
+
+
+@pytest.fixture(scope="session")
+def apt_source_package_api(apt_client):
+    """Fixture for APT source package API."""
+    return ContentSourcePackagesApi(apt_client)
 
 
 @pytest.fixture(scope="session")
@@ -111,6 +126,41 @@ def deb_package_factory(apt_package_api, gen_object_with_cleanup):
         return gen_object_with_cleanup(apt_package_api, **kwargs)
 
     return _deb_package_factory
+
+
+@pytest.fixture(scope="class")
+def deb_source_package_factory(apt_source_package_api, gen_object_with_cleanup):
+    """Fixture that generates deb source package with cleanup."""
+
+    def _deb_source_package_factory(**kwargs):
+        """Create a deb source package.
+
+        :returns: The created source package.
+        """
+        return gen_object_with_cleanup(apt_source_package_api, deb_source_package=kwargs)
+
+    return _deb_source_package_factory
+
+
+@pytest.fixture(scope="class")
+def deb_source_release_component_factory(
+    apt_source_release_components_api, gen_object_with_cleanup
+):
+    """Fixture that generates source release comopnent with cleanup."""
+
+    def _deb_source_release_component_factory(source_package, release_component, **kwargs):
+        """Create an APT SourceReleaseComponent.
+
+        :returns: The created SourceReleaseComponent.
+        """
+        source_release_component_object = DebSourcePackageReleaseComponent(
+            source_package=source_package, release_component=release_component, **kwargs
+        )
+        return gen_object_with_cleanup(
+            apt_source_release_components_api, source_release_component_object
+        )
+
+    return _deb_source_release_component_factory
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
Handle a source package publish IntegrityError when a source package belongs to multiple dists.

fixes #1053