### PR TITLE
Allow source files to publish at by-hash paths

### DIFF
--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -82,7 +82,7 @@ VARSYAML
 
 cat >> vars/main.yaml << VARSYAML
 pulp_env: {}
-pulp_settings: {"allowed_content_checksums": ["md5", "sha1", "sha256", "sha512"], "allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"]}
+pulp_settings: {"allowed_content_checksums": ["md5", "sha1", "sha256", "sha512"], "allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"], "apt_by_hash": true}
 pulp_scheme: https
 pulp_default_container: ghcr.io/pulp/pulp-ci-centos9:latest
 VARSYAML

--- a/CHANGES/1059.feature
+++ b/CHANGES/1059.feature
@@ -1,0 +1,1 @@
+Extend publishing at by-hash paths to source files.

--- a/pulp_deb/app/tasks/publishing.py
+++ b/pulp_deb/app/tasks/publishing.py
@@ -365,19 +365,9 @@ class _ComponentHelper:
 
             # Generating metadata files using checksum
             if settings.APT_BY_HASH:
-                for path, index in (
-                    (package_index_path, package_index),
-                    (gz_package_index_path, gz_package_index),
-                ):
-                    for checksum in settings.ALLOWED_CONTENT_CHECKSUMS:
-                        if checksum in CHECKSUM_TYPE_MAP:
-                            hashed_index_path = _fetch_file_checksum(path, index, checksum)
-                            hashed_index = PublishedMetadata.create_from_file(
-                                publication=self.parent.publication,
-                                file=File(open(path, "rb")),
-                                relative_path=hashed_index_path,
-                            )
-                            hashed_index.save()
+                self.generate_by_hash(
+                    package_index_path, package_index, gz_package_index_path, gz_package_index
+                )
 
             self.parent.add_metadata(package_index)
             self.parent.add_metadata(gz_package_index)
@@ -394,8 +384,30 @@ class _ComponentHelper:
                 publication=self.parent.publication, file=File(open(gz_source_index_path, "rb"))
             )
             gz_source_index.save()
+
+            # Generating metadata files using checksum
+            if settings.APT_BY_HASH:
+                self.generate_by_hash(
+                    source_index_path, source_index, gz_source_index_path, gz_source_index
+                )
+
             self.parent.add_metadata(source_index)
             self.parent.add_metadata(gz_source_index)
+
+    def generate_by_hash(self, index_path, index, gz_index_path, gz_index):
+        for path, index in (
+            (index_path, index),
+            (gz_index_path, gz_index),
+        ):
+            for checksum in settings.ALLOWED_CONTENT_CHECKSUMS:
+                if checksum in CHECKSUM_TYPE_MAP:
+                    hashed_index_path = _fetch_file_checksum(path, index, checksum)
+                    hashed_index = PublishedMetadata.create_from_file(
+                        publication=self.parent.publication,
+                        file=File(open(path, "rb")),
+                        relative_path=hashed_index_path,
+                    )
+                    hashed_index.save()
 
 
 class _ReleaseHelper:

--- a/template_config.yml
+++ b/template_config.yml
@@ -56,6 +56,7 @@ pulp_settings:
   - /tmp
   allowed_import_paths:
   - /tmp
+  apt_by_hash: true
 pulp_settings_azure: null
 pulp_settings_gcp: null
 pulp_settings_s3: null


### PR DESCRIPTION
Refactored the previous AptByHash code to extend publishing at by-hash paths for source files.

Closes #1059