### PR TITLE
Backport 3.1: add retrieve functionality / fix source package publish

### DIFF
--- a/CHANGES/1053.bugfix
+++ b/CHANGES/1053.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug where an ``IntegrityError`` was raised during publish when a source package belonged to
+two dists.

--- a/pulp_deb/app/tasks/publishing.py
+++ b/pulp_deb/app/tasks/publishing.py
@@ -325,14 +325,15 @@ class _ComponentHelper:
     def add_source_package(self, source_package):
         artifact_set = source_package.contentartifact_set.all()
         for content_artifact in artifact_set:
-            published_artifact = PublishedArtifact(
-                relative_path=source_package.derived_path(
-                    os.path.basename(content_artifact.relative_path), self.component
-                ),
-                publication=self.parent.publication,
-                content_artifact=content_artifact,
-            )
-            published_artifact.save()
+            with suppress(IntegrityError):
+                published_artifact = PublishedArtifact(
+                    relative_path=source_package.derived_path(
+                        os.path.basename(content_artifact.relative_path), self.component
+                    ),
+                    publication=self.parent.publication,
+                    content_artifact=content_artifact,
+                )
+                published_artifact.save()
         dsc_file_822_serializer = DscFile822Serializer(source_package, context={"request": None})
         dsc_file_822_serializer.to822(self.component, paragraph=True).dump(
             self.source_index_file_info[0]


### PR DESCRIPTION
Because of the performance tests which split the `conftest.py` and the fact that the source package publish fix uses fixtures introduced in the "add retrieve functionality" there were a lot of merge conflicts which I had to fix manually.

If we don't want to backport the "add retrieve functionality" feature we can just close this PR