### PR TITLE
Create architectures and components when creating a release

### DIFF
--- a/CHANGES/1038.feature
+++ b/CHANGES/1038.feature
@@ -1,0 +1,2 @@
+Added the ``architectures`` and ``components`` parameters to the release API in order to create releases with accompanying architectures and components in a single API call.
+Also added retrieve functionality to the release API.

--- a/CHANGES/1038.removal
+++ b/CHANGES/1038.removal
@@ -1,0 +1,3 @@
+When creating a release, the API now returns a task instead of the release being created.
+In addition, attempting to create a release that already exists will no longer return an error.
+Instead the resulting task will simply list the existing content in its ``created_resources`` field.

--- a/pulp_deb/app/viewsets/content.py
+++ b/pulp_deb/app/viewsets/content.py
@@ -409,7 +409,7 @@ class ReleaseFilter(ContentFilter):
         fields = ["codename", "suite", "distribution", "version", "label", "origin"]
 
 
-class ReleaseViewSet(ContentViewSet):
+class ReleaseViewSet(NoArtifactContentViewSet):
     # The doc string is a top level element of the user facing REST API documentation:
     """
     The Release contains release file fields, that are not relevant to the APT repo structure.

--- a/pulp_deb/tests/functional/api/test_crud_packages.py
+++ b/pulp_deb/tests/functional/api/test_crud_packages.py
@@ -161,3 +161,61 @@ def test_release_architecture_upload(
 
     assert repository.latest_version_href.endswith("/1/")
     assert architecture.pulp_href == architecture2.pulp_href
+
+
+def test_release_comp_arch_upload(
+    deb_get_repository_by_href,
+    deb_repository_factory,
+    deb_release_factory,
+    apt_release_api,
+    apt_release_component_api,
+    apt_release_architecture_api,
+):
+    """Test creating a Release with Components and Architectures directly in a repository."""
+    repository = deb_repository_factory()
+    assert repository.latest_version_href.endswith("/0/")
+
+    distribution = str(uuid4())
+    architectures = [str(uuid4()), str(uuid4())]
+    components = [str(uuid4()), str(uuid4())]
+
+    release_attr = {
+        "repository": repository.pulp_href,
+        "distribution": distribution,
+        "codename": distribution,
+        "suite": distribution,
+        "architectures": architectures,
+        "components": components,
+    }
+
+    release = deb_release_factory(**release_attr)
+    repository = deb_get_repository_by_href(repository.pulp_href)
+    assert repository.latest_version_href.endswith("/1/")
+
+    repo_version_releases = apt_release_api.list(repository_version=repository.latest_version_href)
+    assert len(repo_version_releases.results) == 1
+    assert repo_version_releases.results[0].pulp_href == release.pulp_href
+
+    repo_version_components = apt_release_component_api.list(
+        repository_version=repository.latest_version_href
+    )
+
+    assert len(repo_version_components.results) == 2
+    for component in repo_version_components.results:
+        assert component.distribution == distribution
+        assert component.component in components
+
+    repo_version_architectures = apt_release_architecture_api.list(
+        repository_version=repository.latest_version_href
+    )
+
+    assert len(repo_version_architectures.results) == 2
+    for architecture in repo_version_architectures.results:
+        assert architecture.distribution == distribution
+        assert architecture.architecture in architectures
+
+    release2 = deb_release_factory(**release_attr)
+    repository = deb_get_repository_by_href(repository.pulp_href)
+
+    assert repository.latest_version_href.endswith("/1/")
+    assert release.pulp_href == release2.pulp_href

--- a/pulp_deb/tests/functional/conftest.py
+++ b/pulp_deb/tests/functional/conftest.py
@@ -21,6 +21,7 @@ from pulpcore.client.pulp_deb import (
     Copy,
     DebAptPublication,
     DebCopyApi,
+    DebRelease,
     DebReleaseArchitecture,
     DebReleaseComponent,
     DebSourcePackageReleaseComponent,
@@ -161,6 +162,23 @@ def deb_source_release_component_factory(
         )
 
     return _deb_source_release_component_factory
+
+
+@pytest.fixture(scope="class")
+def deb_release_factory(apt_release_api, gen_object_with_cleanup):
+    """Fixture that generates deb release with cleanup."""
+
+    def _deb_release_factory(codename, suite, distribution, **kwargs):
+        """Create a deb release.
+
+        :returns: The created release.
+        """
+        release_object = DebRelease(
+            codename=codename, suite=suite, distribution=distribution, **kwargs
+        )
+        return gen_object_with_cleanup(apt_release_api, release_object)
+
+    return _deb_release_factory
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
This PR adds the following: 
1. Allows for a single api call to create release, components, and architectures. 
2. Adds retrieve functionality to the release creation endpoint. If a release already exists, then the existing release will be retrieved. 
3. The release creation endpoint did not originally return a task, which is a bug since it can add content to a repository. This PR updates the endpoint to return a task.

closes #1038