### PR TITLE
Remove the checking of existing source debs

### DIFF
--- a/CHANGES/1077.feature
+++ b/CHANGES/1077.feature
@@ -1,0 +1,1 @@
+Added support for duplicate source debs. If an source deb already exists, return it instead of raising an exception.

--- a/CHANGES/1077.removal
+++ b/CHANGES/1077.removal
@@ -1,0 +1,1 @@
+When uploading a source deb that already exists, instead of throwing an exception it will now return the existing source package.

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -1150,15 +1150,6 @@ class SourcePackageSerializer(MultipleArtifactContentSerializer):
                 )
             )
 
-        content = SourcePackage.objects.filter(source=data["source"], version=data["version"])
-        if content.exists():
-            raise ValidationError(
-                _(
-                    "There is already a DSC file with version '{version}' and source name "
-                    "'{source}'."
-                ).format(version=data["version"], source=data["source"])
-            )
-
         artifacts = {data["relative_path"]: data["artifact"]}
         for source in data["checksums_sha256"]:
             content = Artifact.objects.filter(sha256=source["sha256"], size=source["size"])
@@ -1175,6 +1166,12 @@ class SourcePackageSerializer(MultipleArtifactContentSerializer):
 
         data["artifacts"] = artifacts
         return data
+
+    def retrieve(self, data):
+        """
+        If the Source Package already exists, retrieve it
+        """
+        return SourcePackage.objects.filter(source=data["source"], version=data["version"]).first()
 
     class Meta:
         fields = MultipleArtifactContentSerializer.Meta.fields + (


### PR DESCRIPTION
Remove the checking of existing source debs and instead return the existing source package. Fixes #1077