### PR TITLE
Support per-component/architecture Release files

### DIFF
--- a/pulp_deb/app/tasks/publishing.py
+++ b/pulp_deb/app/tasks/publishing.py
@@ -298,14 +298,14 @@ class _ComponentHelper:
                 "dists",
                 self.parent.dists_subfolder,
                 self.plain_component,
-                "binary-{}".format(architecture),                                              
-                "Release",             
+                "binary-{}".format(architecture),
+                "Release",
             )
             with open(release_path, "w") as file:
                 file.write("Origin: {}\n".format(self.parent._release.origin))
                 file.write("Label: {}\n".format(self.parent._release.label))
                 file.write("Suite: {}\n".format(self.parent._release.suite))
-                file.write("Architecture: {}\n".format(architecture) )
+                file.write("Architecture: {}\n".format(architecture))
                 file.write("Component: {}\n".format(self.plain_component))
             self.release_file_paths[architecture] = release_path
 
@@ -323,7 +323,6 @@ class _ComponentHelper:
             source_index_path,
         )
 
-    
     def add_package(self, package):
         with suppress(IntegrityError):
             published_artifact = PublishedArtifact(


### PR DESCRIPTION
Certain installers, namely ubiquity and debian-installer (see [1]) "cross-validate" the architectures provided by deb-repositories by checking if the binary subdirectories contain files named "Release"  (i.e. $DIST/$COMPONENT/binary-$ARCH/Release). Most if not all upstream deb-repositories provide such files (see for example [2]).

The change proposed by this PR generates and publishes such per-architecture Release files.

[1] https://salsa.debian.org/installer-team/choose-mirror/-/blob/master/choose-mirror.c?ref_type=heads#L877
[2] http://archive.ubuntu.com/ubuntu/dists/noble/main/binary-amd64/