### PR TITLE
Expose the sha256 for source package dsc files

### DIFF
--- a/CHANGES/+add-dsc-sha256.feature
+++ b/CHANGES/+add-dsc-sha256.feature
@@ -1,0 +1,1 @@
+Expose a sha256 column for source packages that contains the digest of the dsc file.

--- a/pulp_deb/app/models/content/content.py
+++ b/pulp_deb/app/models/content/content.py
@@ -197,6 +197,11 @@ class SourcePackage(Content):
                 kwargs.pop(kw)
         super().__init__(*args, **kwargs)
 
+    @property
+    def sha256(self):
+        """Return the sha256 of the dsc file."""
+        return self.contentartifact_set.get(relative_path=self.relative_path).artifact.sha256
+
     def derived_dsc_filename(self):
         """Print a nice name for the Dsc file."""
         return "{}_{}.{}".format(self.source, self.version, self.SUFFIX)

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -1146,6 +1146,7 @@ class SourcePackageSerializer(MultipleArtifactContentSerializer):
         ),
         required=False,
     )
+    sha256 = CharField(help_text=_("sha256 digest of the dsc file."), read_only=True)
     format = CharField(read_only=True)
     source = CharField(read_only=True)
     binary = CharField(read_only=True)
@@ -1245,6 +1246,7 @@ class SourcePackageSerializer(MultipleArtifactContentSerializer):
         fields = MultipleArtifactContentSerializer.Meta.fields + (
             "artifact",
             "relative_path",
+            "sha256",
             "format",
             "source",
             "binary",

--- a/pulp_deb/app/viewsets/content.py
+++ b/pulp_deb/app/viewsets/content.py
@@ -596,7 +596,7 @@ class SourcePackageViewSet(SingleArtifactContentUploadViewSet):
     """
 
     endpoint_name = "source_packages"
-    queryset = models.SourcePackage.objects.prefetch_related("_artifacts")
+    queryset = models.SourcePackage.objects.prefetch_related("_artifacts", "contentartifact_set")
     serializer_class = serializers.SourcePackageSerializer
     filterset_class = SourcePackageFilter
 


### PR DESCRIPTION
We'd like to be able to have a sha256 column for Source Packages like we do for packages. This would save us an extra call to the artifact endpoint.

[noissue]