### PR TITLE
Added support for syncing DEP11 files

### DIFF
--- a/CHANGES/1276.feature
+++ b/CHANGES/1276.feature
@@ -1,0 +1,1 @@
+Added support to sync DEP11 metadata files if available in the source repo.


### PR DESCRIPTION
This change aims to add support for syncing of DEP11 metadata files, enabling the use of application stores like KDE Discover which are based on Appstream.

closes: #1276 