### PR TITLE
Fix duplicate release-content during copy

### DIFF
--- a/CHANGES/1309.bugfix
+++ b/CHANGES/1309.bugfix
@@ -1,0 +1,1 @@
+CopyContent between repository-versions with same distribution-name but different Release content-units fails. Fixed by not copying Release content-unit for distribution-name that already is present in target-version.


### PR DESCRIPTION
This happens if repository-versions exist with different releases that have the same value for 'distribution'. If we copy packages between these repository-versions, then release would be copied as well due to structured-content. Multiple releases in a repository-version is only allowed, if they differ in 'distribution', resulting in validate_duplicate_content() reporting an error.
Also removed remove_duplicate_content(), because it never did anything being called after validate_duplicate_content()

closes #1309