### PR TITLE
Update Azure and S3 storage settings for main

### DIFF
--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -105,7 +105,7 @@ if [ "$TEST" = "s3" ]; then
   sed -i -e '$a s3_test: true\
 minio_access_key: "'$MINIO_ACCESS_KEY'"\
 minio_secret_key: "'$MINIO_SECRET_KEY'"\
-pulp_scenario_settings: null\
+pulp_scenario_settings: {"MEDIA_ROOT": "", "STORAGES": {"default": {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage", "OPTIONS": {"access_key": "AKIAIT2Z5TDYPX3ARJBA", "addressing_style": "path", "bucket_name": "pulp3", "default_acl": "@none", "endpoint_url": "http://minio:9000", "region_name": "eu-central-1", "secret_key": "fqRvjWaPU5o0fCqQuUWbj9Fainj2pVZtBCiDiieS", "signature_version": "s3v4"}}, "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}}}\
 pulp_scenario_env: {}\
 ' vars/main.yaml
   export PULP_API_ROOT="/rerouted/djnd/"
@@ -119,7 +119,7 @@ if [ "$TEST" = "azure" ]; then
       - ./azurite:/etc/pulp\
     command: "azurite-blob --blobHost 0.0.0.0"' vars/main.yaml
   sed -i -e '$a azure_test: true\
-pulp_scenario_settings: {"domain_enabled": true}\
+pulp_scenario_settings: {"MEDIA_ROOT": "", "STORAGES": {"default": {"BACKEND": "storages.backends.azure_storage.AzureStorage", "OPTIONS": {"account_key": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "account_name": "devstoreaccount1", "azure_container": "pulp-test", "connection_string": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://ci-azurite:10000/devstoreaccount1;", "expiration_secs": 120, "location": "pulp3", "overwrite_files": true}}, "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}}, "domain_enabled": true}\
 pulp_scenario_env: {}\
 ' vars/main.yaml
 fi

--- a/template_config.yml
+++ b/template_config.yml
@@ -53,9 +53,38 @@ pulp_settings:
   - /tmp
   apt_by_hash: true
 pulp_settings_azure:
+  MEDIA_ROOT: ''
+  STORAGES:
+    default:
+      BACKEND: storages.backends.azure_storage.AzureStorage
+      OPTIONS:
+        account_key: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+        account_name: devstoreaccount1
+        azure_container: pulp-test
+        connection_string: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://ci-azurite:10000/devstoreaccount1;
+        expiration_secs: 120
+        location: pulp3
+        overwrite_files: true
+    staticfiles:
+      BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
   domain_enabled: true
 pulp_settings_gcp: null
-pulp_settings_s3: null
+pulp_settings_s3:
+  MEDIA_ROOT: ''
+  STORAGES:
+    default:
+      BACKEND: storages.backends.s3boto3.S3Boto3Storage
+      OPTIONS:
+        access_key: AKIAIT2Z5TDYPX3ARJBA
+        addressing_style: path
+        bucket_name: pulp3
+        default_acl: '@none'
+        endpoint_url: http://minio:9000
+        region_name: eu-central-1
+        secret_key: fqRvjWaPU5o0fCqQuUWbj9Fainj2pVZtBCiDiieS
+        signature_version: s3v4
+    staticfiles:
+      BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
 pydocstyle: true
 release_email: pulp-infra@redhat.com
 release_user: pulpbot


### PR DESCRIPTION
Set storage settings in template_config.yml based on pulpcore requirement (>=3.75.0,<3.100).

Storage formats: Azure (new STORAGES), S3 (new STORAGES)

This addresses the recent change where plugin-template stopped automatically setting test scenario storage settings and now requires plugins to define them in their template_config.yml.