### PR TITLE
Fix an import/export bug when domains are enabled.

### DIFF
--- a/CHANGES/+import_export_domain_enable.bugfix
+++ b/CHANGES/+import_export_domain_enable.bugfix
@@ -1,0 +1,1 @@
+Allow pulp-import-export when domains are enabled.

--- a/pulp_deb/app/modelresource.py
+++ b/pulp_deb/app/modelresource.py
@@ -3,6 +3,8 @@ from import_export.widgets import ForeignKeyWidget
 
 from pulpcore.plugin.importexport import BaseContentResource
 from pulpcore.plugin.modelresources import RepositoryResource
+from pulpcore.plugin.util import get_domain
+
 from pulp_deb.app.models import (
     AptRepository,
     GenericContent,
@@ -52,6 +54,9 @@ class DebContentResource(BaseContentResource):
         )
 
         return content
+
+    def dehydrate__pulp_domain(self, content):
+        return str(content._pulp_domain_id)
 
 
 class InstallerFileIndexResource(DebContentResource):
@@ -156,10 +161,10 @@ class PackageReleaseComponentResource(DebContentResource):
         str(<release_component.distribution>|<release_component.component>)
         """
 
-        def render(self, value, obj):
+        def render(self, value, obj=None, **kwargs):
             """Render formatted string to use as unique-identifier."""
-            rc_dist = obj.release_component.distribution
-            rc_comp = obj.release_component.component
+            rc_dist = value.distribution
+            rc_comp = value.component
             return f"{rc_dist}|{rc_comp}"
 
     class PackageForeignKeyWidget(ForeignKeyWidget):
@@ -170,10 +175,10 @@ class PackageReleaseComponentResource(DebContentResource):
         str(<package.relative_path>|<package.sha256>)
         """
 
-        def render(self, value, obj):
+        def render(self, value, obj=None, **kwargs):
             """Render formatted string to use as unique-identifier."""
-            pkg_relative_path = obj.package.relative_path
-            pkg_sha256 = obj.package.sha256
+            pkg_relative_path = value.relative_path
+            pkg_sha256 = value.sha256
             return f"{pkg_relative_path}|{pkg_sha256}"
 
     release_component = fields.Field(
@@ -200,8 +205,12 @@ class PackageReleaseComponentResource(DebContentResource):
 
         (rc_dist, rc_comp) = row["release_component"].split("|")
         (pkg_relative_path, pkg_sha256) = row["package"].split("|")
-        rc = ReleaseComponent.objects.filter(distribution=rc_dist, component=rc_comp).first()
-        pkg = Package.objects.filter(relative_path=pkg_relative_path, sha256=pkg_sha256).first()
+        rc = ReleaseComponent.objects.filter(
+            distribution=rc_dist, component=rc_comp, pulp_domain=get_domain()
+        ).first()
+        pkg = Package.objects.filter(
+            relative_path=pkg_relative_path, sha256=pkg_sha256, pulp_domain=get_domain()
+        ).first()
         row["release_component"] = str(rc.pulp_id)
         row["package"] = str(pkg.pulp_id)
 

--- a/pulp_deb/tests/functional/api/test_pulpexport_pulpimport.py
+++ b/pulp_deb/tests/functional/api/test_pulpexport_pulpimport.py
@@ -9,14 +9,10 @@ import pytest
 
 from uuid import uuid4
 
-from pulpcore.app import settings
 from pulp_deb.tests.functional.constants import DEB_FIXTURE_SUMMARY
 from pulp_deb.tests.functional.utils import get_counts_from_content_summary
 
 NUM_REPOS = 2
-
-if settings.DOMAIN_ENABLED:
-    pytest.skip("Domains do not support import.", allow_module_level=True)
 
 
 @pytest.fixture
@@ -200,9 +196,13 @@ def test_import(
     deb_get_repository_by_href,
     deb_importer_factory,
     deb_perform_import,
+    has_pulp_plugin,
     is_chunked,
+    pulp_settings,
 ):
     """Test a PulpImport."""
+    if pulp_settings.DOMAIN_ENABLED and not has_pulp_plugin("core", min="3.90.0"):
+        pytest.skip("Pulp Import/Export only supported under domains in core>=3.90")
     import_repos, export_repos = deb_gen_import_export_repos()
     importer = deb_importer_factory(import_repos, export_repos)
     task_group = deb_perform_import(importer, import_repos, export_repos, is_chunked=is_chunked)
@@ -218,9 +218,13 @@ def test_double_import(
     deb_get_repository_by_href,
     deb_importer_factory,
     deb_perform_import,
+    has_pulp_plugin,
     pulpcore_bindings,
+    pulp_settings,
 ):
     """Test two PulpImports for a PulpExport."""
+    if pulp_settings.DOMAIN_ENABLED and not has_pulp_plugin("core", min="3.90.0"):
+        pytest.skip("Pulp Import/Export only supported under domains in core>=3.90")
     import_repos, export_repos = deb_gen_import_export_repos()
     importer = deb_importer_factory(import_repos, export_repos)
     deb_perform_import(importer, import_repos, export_repos)
@@ -234,8 +238,16 @@ def test_double_import(
         assert repo.latest_version_href.endswith("versions/1/")
 
 
-def test_export(deb_create_exporter, deb_create_export, deb_gen_import_export_repos):
+def test_export(
+    deb_create_exporter,
+    deb_create_export,
+    deb_gen_import_export_repos,
+    has_pulp_plugin,
+    pulp_settings,
+):
     """Issue and evaluate a PulpExport."""
+    if pulp_settings.DOMAIN_ENABLED and not has_pulp_plugin("core", min="3.90.0"):
+        pytest.skip("Pulp Import/Export only supported under domains in core>=3.90")
     import_repos, export_repos = deb_gen_import_export_repos()
     exporter = deb_create_exporter(import_repos, export_repos)
     export = deb_create_export(import_repos, export_repos, exporter)
@@ -256,11 +268,15 @@ def test_import_create_repos(
     deb_importer_factory,
     deb_init_and_sync,
     deb_perform_import,
+    has_pulp_plugin,
     pulpcore_bindings,
+    pulp_settings,
     monitor_task,
     delete_orphans_pre,
 ):
     """Test whether PulpImporter can create repositories."""
+    if pulp_settings.DOMAIN_ENABLED and not has_pulp_plugin("core", min="3.90.0"):
+        pytest.skip("Pulp Import/Export only supported under domains in core>=3.90")
     entity_map = {}
     repo, remote = deb_init_and_sync(remote_args={"policy": "immediate"})
     entity_map["repo"] = repo


### PR DESCRIPTION
Also enabled import/export tests when domains are enabled, and made it possible for pulp-deb import/export to work when django-import-export==4.x is in use.