### PR TITLE
Stop asserting task error descriptions for invalid deb sync

### DIFF
--- a/pulp_deb/tests/functional/api/test_duplicate_packages.py
+++ b/pulp_deb/tests/functional/api/test_duplicate_packages.py
@@ -18,6 +18,7 @@ from pulp_deb.tests.functional.constants import DEB_PACKAGE_RELPATH
 from pulp_deb.tests.functional.utils import (
     get_counts_from_content_summary,
     get_local_package_absolute_path,
+    get_task_error_message,
 )
 
 DUPLICATE_PACKAGE_DIR = "data/packages/duplicates/"  # below pulp_deb/tests/functional/
@@ -132,6 +133,5 @@ def test_add_duplicates_to_repo(
         deb_modify_repository(repository, {"add_content_units": [href1, href2]})
 
     # Assert the error message.
-    assert "Cannot create repository version since there are newly added packages with" in str(
-        exception.value.task.error["description"]
-    )
+    msg = get_task_error_message(exception.value.task.error)
+    assert "Cannot create repository version since there are newly added packages with" in msg

--- a/pulp_deb/tests/functional/api/test_sync.py
+++ b/pulp_deb/tests/functional/api/test_sync.py
@@ -21,7 +21,7 @@ from pulp_deb.tests.functional.constants import (
     DEB_REPORT_CODE_SKIP_COMPLETE,
     DEB_SIGNING_KEY,
 )
-from pulp_deb.tests.functional.utils import get_counts_from_content_summary
+from pulp_deb.tests.functional.utils import get_counts_from_content_summary, get_task_error_message
 
 
 @pytest.mark.parallel
@@ -121,7 +121,7 @@ def test_sync_missing_package_indices(
 @pytest.mark.parametrize(
     "repo_name, remote_args, expected",
     [
-        ("http://i-am-an-invalid-url.com/invalid/", {}, ["Cannot connect"]),
+        ("http://i-am-an-invalid-url.com/invalid/", {}, ["cannot connect"]),
         (
             DEB_FIXTURE_STANDARD_REPOSITORY_NAME,
             {"distributions": "no_dist"},
@@ -162,8 +162,9 @@ def test_sync_invalid_cases(
     # Verify a PulpTaskError is raised and the error message is as expected
     with pytest.raises(PulpTaskError) as exc:
         deb_sync_repository(remote, repo)
+    msg = get_task_error_message(exc.value.task.error).lower()
     for exp in expected:
-        assert exp in str(exc.value.task.error["description"])
+        assert exp.lower() in msg
 
 
 @pytest.mark.parallel

--- a/pulp_deb/tests/functional/utils.py
+++ b/pulp_deb/tests/functional/utils.py
@@ -109,3 +109,9 @@ def get_counts_from_content_summary(content_summary):
     for key in content:
         content[key] = content[key]["count"]
     return content
+
+
+def get_task_error_message(error):
+    if not error:
+        return ""
+    return str(error.get("description") or error.get("detail") or error.get("message") or error)


### PR DESCRIPTION
fixes ci pipeline due to pulp tasks no longer providing clear task descriptions
