### PR TITLE
Extend the call repository content modify to include DEB release components

### DIFF
--- a/CHANGES/1398.feature
+++ b/CHANGES/1398.feature
@@ -1,0 +1,1 @@
+Allow adding/removing package_release_components, release_components and release_architectures via the repository content modify API endpoint

--- a/pulp_deb/app/serializers/__init__.py
+++ b/pulp_deb/app/serializers/__init__.py
@@ -31,6 +31,7 @@ from .repository_serializers import (
     AptRepositorySerializer,
     AptRepositorySyncURLSerializer,
     CopySerializer,
+    AptRepositoryAddRemoveContentSerializer,
 )
 
 from .acs_serializers import AptAlternateContentSourceSerializer


### PR DESCRIPTION
This commit extends the repository content modify call to additional components such as `package_release_components`, `release_components` and `release_architectures`, with the final goal of enabling batch uploading of `DEB` packages. This is done by:

1. Adding `AptRepositoryAddRemoveContentSerializer` for extending the parameters allowed in the repository content modify call to:
- `add_release_components`
- `add_release_architectures`
- `add_package_release_components`
- `remove_release_components`
- `remove_release_architectures`
- `remove_package_release_components`

2. Updating the viewset `AptModifyRepositoryActionMixin` to include also package_release_components, release_components and release_architectures as they also extend from Content.

Closes #1398 

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
