### PR TITLE
Test PR against pulpcore#7546

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include CHANGES.md
 include COMMITMENT
 exclude CONTRIBUTING.md
 include COPYRIGHT
+include ci_requirements.txt
 include functest_requirements.txt
 include LICENSE
 include pulp_deb/app/schema/*

--- a/ci_requirements.txt
+++ b/ci_requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/pulp/pulpcore@refs/pull/7546/head


### PR DESCRIPTION
## Summary

- Adds `ci_requirements.txt` pointing to pulp/pulpcore#7546 head to test compatibility before release
- Adds `ci_requirements.txt` to `MANIFEST.in` so it is included in the source distribution

## Test plan

- [x] CI passes with the pinned pulpcore PR head

🤖 Generated with [Claude Code](https://claude.com/claude-code)