### PR TITLE
Filter serializer validated_data to model fields

### DIFF
--- a/CHANGES/+filter_validated_data.bugfix
+++ b/CHANGES/+filter_validated_data.bugfix
@@ -1,0 +1,2 @@
+Filter serializer validated data to only include model fields, preventing errors from extra fields
+(e.g. ``overwrite``) added to pulpcore's ``ContentSerializer``.

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -627,7 +627,13 @@ class BasePackageMixin(Serializer):
 
         from822_serializer = self.Meta.from822_serializer.from822(data=package_paragraph)
         from822_serializer.is_valid(raise_exception=True)
-        package_data = from822_serializer.validated_data
+        # Filter to model fields: validated_data may carry extra serializer-only fields from
+        # pulpcore's ContentSerializer (e.g. ``overwrite``) that would otherwise be forwarded
+        # to ``self.Meta.model(**package_data)`` and raise a TypeError.
+        model_fields = {f.name for f in self.Meta.model._meta.get_fields()}
+        package_data = {
+            k: v for k, v in from822_serializer.validated_data.items() if k in model_fields
+        }
         data.update(package_data)
         data["sha256"] = data["artifact"].sha256
 

--- a/pulp_deb/app/tasks/synchronizing.py
+++ b/pulp_deb/app/tasks/synchronizing.py
@@ -1054,10 +1054,14 @@ class DebFirstStage(Stage):
                 log.debug(_("Downloading package {}").format(package_paragraph["Package"]))
                 serializer = serializer_class.from822(data=package_paragraph)
                 serializer.is_valid(raise_exception=True)
+                model_fields = {f.name for f in package_class._meta.get_fields()}
+                content_data = {
+                    k: v for k, v in serializer.validated_data.items() if k in model_fields
+                }
                 package_content_unit = package_class(
                     relative_path=package_relpath,
                     sha256=package_sha256,
-                    **serializer.validated_data,
+                    **content_data,
                 )
                 package_path = quote(os.path.join(self.parsed_url.path, package_relpath), safe=":/")
                 package_da = DeclarativeArtifact(
@@ -1174,9 +1178,13 @@ class DebFirstStage(Stage):
                 source_relpath = os.path.join(source_dir, "blah")
                 serializer = DscFile822Serializer.from822(data=source_paragraph)
                 serializer.is_valid(raise_exception=True)
+                model_fields = {f.name for f in SourcePackage._meta.get_fields()}
+                content_data = {
+                    k: v for k, v in serializer.validated_data.items() if k in model_fields
+                }
                 source_content_unit = SourcePackage(
                     relative_path=source_relpath,
-                    **serializer.validated_data,
+                    **content_data,
                 )
                 # Handle the dsc file content
                 source_das = []


### PR DESCRIPTION
The serializer's validated_data may contain fields from pulpcore's ContentSerializer (e.g. 'overwrite') that don't exist on the plugin model. Filter validated_data against the model's actual fields before passing it to the constructor.