### PR TITLE
Fix link for verbatim publishing

### DIFF
--- a/docs/user/guides/publish.md
+++ b/docs/user/guides/publish.md
@@ -66,7 +66,7 @@ At the time of this writing, this cannot be done via Pulp CLI.
 ## Verbatim Publications
 
 !!! attention
-    For an explanation on what a verbatim publication is, see the corresponding [feature overview](https://staging-docs.pulpproject.org/pulp_deb/docs/user/overview).
+    For an explanation on what a verbatim publication is, see the corresponding [feature overview](https://staging-docs.pulpproject.org/pulp_deb/docs/user/#verbatim-publishing).
 
 
 The following example uses a verbatim publication to host an official Debian repository, including the installer files:


### PR DESCRIPTION
As mentioned in #1460 the link for verbatim publishing results in a 404. This fix points to the documentation suggested by @quba42 

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
