### PR TITLE
Fix import oversight in test

### DIFF
--- a/pulp_deb/tests/functional/api/test_sync.py
+++ b/pulp_deb/tests/functional/api/test_sync.py
@@ -1,8 +1,8 @@
 """Tests that sync deb repositories in optimized mode."""
 
 import pytest
+from django.conf import settings
 
-from pulpcore.app import settings  # noqa: TID251
 from pulpcore.tests.functional.utils import PulpTaskError
 
 from pulp_deb.tests.functional.constants import (


### PR DESCRIPTION
Import settings from django.conf instead of pulpcore.app.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
