### PR TITLE
Scope signed package components to repository

### DIFF
--- a/CHANGES/1493.bugfix
+++ b/CHANGES/1493.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where signing a package shared by multiple repositories could add package release-component associations from other repositories to the repository being modified.

--- a/pulp_deb/app/tasks/signing.py
+++ b/pulp_deb/app/tasks/signing.py
@@ -134,7 +134,7 @@ def sign_and_create(
     general_create(app_label, serializer_name, data=data, context=context, *args, **kwargs)
 
 
-def _sign_package(package, signing_service, signing_fingerprint, package_release_map):
+def _sign_package(package, signing_service, signing_fingerprint, prcs):
     """
     Sign a package or reuse an existing signed result.
 
@@ -155,11 +155,7 @@ def _sign_package(package, signing_service, signing_fingerprint, package_release
             return None
 
         # Collect PackageReleaseComponents that need to be updated
-        prcs_to_update = list(
-            PackageReleaseComponent.objects.filter(
-                package_id=package_id, _pulp_domain=package._pulp_domain
-            )
-        )
+        prcs_to_update = list(prcs.filter(package_id=package_id))
 
         # check if the package has been signed in the past with our fingerprint
         if existing_result := DebPackageSigningResult.objects.filter(
@@ -239,7 +235,7 @@ def signed_add_and_remove(
                         pkg,
                         repo.package_signing_service,
                         fingerprint,
-                        package_release_map,
+                        prcs,
                     )
 
             return await asyncio.gather(*(_bounded_sign(pkg_tuple) for pkg_tuple in packages))

--- a/pulp_deb/tests/functional/api/test_package_signing.py
+++ b/pulp_deb/tests/functional/api/test_package_signing.py
@@ -411,6 +411,38 @@ def test_signed_repo_modify_overwrite_false_noop(
     assert [signed_package.pulp_href] == [pkg.pulp_href for pkg in results]
 
 
+def test_signing_does_not_add_package_components_from_other_repositories(
+    tmp_path,
+    add_package_to_repo,
+    deb_signing_key_primary,
+    deb_package_signing_service,
+    deb_repository_factory,
+    deb_package_factory,
+    apt_repository_api,
+    apt_package_release_components_api,
+):
+    """Ensure signing only replaces package components belonging to the target repository."""
+    package_file = shutil.copy(
+        get_local_package_absolute_path("frigg_1.0_ppc64.deb"),
+        tmp_path,
+    )
+    package = deb_package_factory(file=package_file)
+    other_repository = deb_repository_factory()
+    add_package_to_repo(other_repository, package.pulp_href)
+
+    repository = deb_repository_factory(
+        package_signing_service=deb_package_signing_service.pulp_href,
+        package_signing_fingerprint=deb_signing_key_primary.fingerprint,
+    )
+    release_component, _ = add_package_to_repo(repository, package.pulp_href)
+
+    repository = apt_repository_api.read(repository.pulp_href)
+    package_components = apt_package_release_components_api.list(
+        repository_version=repository.latest_version_href
+    ).results
+    assert [component.release_component for component in package_components] == [release_component]
+
+
 def test_already_signed_package(
     tmp_path,
     add_package_to_repo,


### PR DESCRIPTION
Prevent package signing from adding release-component associations belonging to other repositories.

fixes #1493