### PR TITLE
Added PackageViewSet policy for the deb package to allow set and unset labels

### DIFF
--- a/CHANGES/1504.feature
+++ b/CHANGES/1504.feature
@@ -1,0 +1,1 @@
+Allowed users with the content label management permission to set and unset labels on DEB packages.

--- a/pulp_deb/app/viewsets/content.py
+++ b/pulp_deb/app/viewsets/content.py
@@ -262,6 +262,12 @@ class PackageViewSet(SingleArtifactContentUploadViewSet):
                     "has_required_repo_perms_on_upload:deb.view_aptrepository",
                 ],
             },
+            {
+                "action": ["set_label", "unset_label"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": ["has_model_or_domain_perms:core.manage_content_labels"],
+            },
         ],
         "queryset_scoping": {"function": "scope_queryset"},
     }

--- a/pulp_deb/tests/functional/api/test_crud_packages.py
+++ b/pulp_deb/tests/functional/api/test_crud_packages.py
@@ -4,6 +4,9 @@ from uuid import uuid4
 
 import pytest
 
+from pulpcore.client.pulp_deb import SetLabel, UnsetLabel
+from pulpcore.client.pulp_deb.exceptions import ForbiddenException
+
 from pulp_deb.tests.functional.constants import DEB_PACKAGE_RELPATH
 from pulp_deb.tests.functional.utils import get_local_package_absolute_path
 
@@ -41,6 +44,44 @@ def test_create_package(apt_package_api, deb_package_factory):
     with pytest.raises(AttributeError) as exc:
         apt_package_api.delete(package.pulp_href)
     assert "object has no attribute 'delete'" in exc.value.args[0]
+
+
+@pytest.mark.parallel
+def test_set_unset_package_labels(
+    apt_package_api, deb_package_factory, deb_repository_factory, gen_user
+):
+    """Verify package labels require the content label management permission."""
+    repository = deb_repository_factory()
+    deb_package_factory(
+        relative_path=DEB_PACKAGE_RELPATH,
+        file=str(get_local_package_absolute_path(DEB_PACKAGE_RELPATH)),
+        repository=repository.pulp_href,
+    )
+    package = apt_package_api.list(relative_path=DEB_PACKAGE_RELPATH).results[0]
+    content_labeler = gen_user(model_roles=["deb.admin", "core.content_labeler"])
+    user_denied = gen_user(model_roles=["deb.admin"])
+
+    with content_labeler:
+        apt_package_api.set_label(
+            package.pulp_href,
+            SetLabel(key="test-label", value="test-value"),
+        )
+        package = apt_package_api.read(package.pulp_href)
+        assert package.pulp_labels["test-label"] == "test-value"
+
+        apt_package_api.unset_label(package.pulp_href, UnsetLabel(key="test-label"))
+        package = apt_package_api.read(package.pulp_href)
+        assert "test-label" not in package.pulp_labels
+
+    with user_denied:
+        with pytest.raises(ForbiddenException):
+            apt_package_api.set_label(
+                package.pulp_href,
+                SetLabel(key="test-label", value="test-value"),
+            )
+
+        with pytest.raises(ForbiddenException):
+            apt_package_api.unset_label(package.pulp_href, UnsetLabel(key="test-label"))
 
 
 def test_same_sha256_same_relative_path_no_repo(


### PR DESCRIPTION
<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
