### PR TITLE
Do not create ReleaseArchitecture for arch=all

### DIFF
--- a/CHANGES/+no-arch-all-validation.removal
+++ b/CHANGES/+no-arch-all-validation.removal
@@ -1,0 +1,2 @@
+Added validation that prevents users from creating ReleaseArchitecture content for the special value "Architecture: all".
+If you have previously created the content unit you can keep using it.

--- a/pulp_deb/app/serializers/content_serializers.py
+++ b/pulp_deb/app/serializers/content_serializers.py
@@ -913,6 +913,16 @@ class ReleaseArchitectureSerializer(NoArtifactContentSerializer):
         help_text="Architecture variant name, if this architecture is a variant.",
     )
 
+    def validate(self, data):
+        """
+        Ensure we do not create a ReleaseArchitecture object for special value 'all'.
+        """
+        data = super().validate(data)
+        if data.get("architecture") == "all":
+            message = "This field does not accept the special value 'all'!"
+            raise ValidationError({"architecture": _(message)})
+        return data
+
     def get_unique_together_validators(self):
         """
         We do not want UniqueTogetherValidator since we have retrieve logic!


### PR DESCRIPTION
The goal is to make a piece of implicit plugin design explicit.

The idea came up during the review of #1492.