### PR TITLE
Handle architecture all in repository modify

### DIFF
--- a/CHANGES/+repository-modify-architecture-all.bugfix
+++ b/CHANGES/+repository-modify-architecture-all.bugfix
@@ -1,0 +1,1 @@
+Fixed modifying a repository with an architecture-independent package when distribution or component fields were provided.

--- a/pulp_deb/app/tasks/signing.py
+++ b/pulp_deb/app/tasks/signing.py
@@ -127,10 +127,11 @@ def _prepare_package_additions(add_content_units, distribution, component):
             architecture, _ = ReleaseArchitecture.objects.get_or_create(
                 distribution=distribution, architecture=package.architecture
             )
+            add_content_units.append(str(architecture.pk))
         package_component, _ = PackageReleaseComponent.objects.get_or_create(
             release_component=release_component, package=package
         )
-        add_content_units.extend([str(architecture.pk), str(package_component.pk)])
+        add_content_units.append(str(package_component.pk))
     # Source packages only need a link to the release component.
     for source_package in source_packages:
         source_package_component, _ = SourcePackageReleaseComponent.objects.get_or_create(

--- a/pulp_deb/tests/functional/api/test_repository_modify.py
+++ b/pulp_deb/tests/functional/api/test_repository_modify.py
@@ -62,6 +62,37 @@ def test_modify_package_creates_structure_without_release(
     assert [item.pulp_href for item in packages.results] == [package.pulp_href]
 
 
+def test_modify_architecture_all_package_creates_no_release_architecture(
+    apt_package_release_components_api,
+    apt_release_architecture_api,
+    deb_get_repository_by_href,
+    deb_modify_repository,
+    deb_package_factory,
+    deb_repository_factory,
+):
+    repository = deb_repository_factory()
+    package = deb_package_factory(
+        file=str(
+            get_local_package_absolute_path(
+                "eir_1.0_all.deb", relative_path="data/debian-mixed/pool/asgard/e/eir/"
+            )
+        )
+    )
+
+    _modify_with_package(
+        repository,
+        package,
+        deb_modify_repository,
+        distribution=str(uuid4()),
+        component=str(uuid4()),
+    )
+    repository = deb_get_repository_by_href(repository.pulp_href)
+
+    filters = {"repository_version": repository.latest_version_href}
+    assert apt_release_architecture_api.list(**filters).count == 0
+    assert apt_package_release_components_api.list(**filters).count == 1
+
+
 def test_modify_package_without_structure_fields_only_adds_package(
     apt_package_release_components_api,
     apt_release_architecture_api,


### PR DESCRIPTION
## Summary
- Repository modify previously accessed an unassigned/stale ReleaseArchitecture for `Architecture: all`.
- It now only adds ReleaseArchitecture content for concrete architectures while retaining PackageReleaseComponent.

## Testing
- `oci-env test -p pulp_deb functional -k test_repository_modify -vv`
- Result: 12 passed, 1 skipped

## Context
- Follows #1492 and complements #1513.

Assisted By: GitHub Copilot